### PR TITLE
add no date mutation rule, and reorganize test folder

### DIFF
--- a/docs/rules/no-date-mutation.md
+++ b/docs/rules/no-date-mutation.md
@@ -1,0 +1,255 @@
+# no-date-mutation
+
+Disallow in-place mutation of `Date` instances. Prefer immutable date-fns alternatives.
+
+🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/use/command-line-interface#--fix)
+
+💡 Provides suggestions for ambiguous cases
+
+## Rule Details
+
+This rule enforces immutable date operations by disallowing direct mutation of Date objects through setter methods. Instead, it requires using date-fns v4 functions which return new Date instances.
+
+JavaScript's `Date` object is mutable by default, which can lead to:
+- Unintended side effects when dates are shared across code
+- Difficult-to-debug mutation-at-a-distance issues
+- Testing challenges requiring extensive mocking
+- Inconsistency with modern functional programming practices
+
+This rule automatically converts most mutation patterns to immutable date-fns equivalents, and provides suggestions for ambiguous cases.
+
+## Examples
+
+### ❌ Incorrect
+
+```js
+/*eslint date-fns/no-date-mutation: "error"*/
+
+// Simple field mutation
+const d = new Date();
+d.setHours(14);
+
+// Arithmetic mutation
+const d2 = new Date();
+d2.setMonth(d2.getMonth() + 1);
+
+// Function parameter mutation
+function updateDate(date) {
+  date.setFullYear(2024);
+}
+
+// Midnight zeroing
+d.setHours(0, 0, 0, 0);
+
+// Timestamp mutation
+d.setTime(1609459200000);
+
+// UTC mutation
+d.setUTCDate(15);
+
+// Consecutive mutations
+d.setFullYear(2024);
+d.setMonth(5);
+d.setDate(15);
+```
+
+### ✅ Correct
+
+```js
+/*eslint date-fns/no-date-mutation: "error"*/
+
+import { set, addMonths, startOfDay, toDate } from 'date-fns';
+import { tz } from '@date-fns/tz';
+
+// Simple field update
+let d = new Date();
+d = set(d, { hours: 14 });
+
+// Arithmetic
+let d2 = new Date();
+d2 = addMonths(d2, 1);
+
+// Function parameter (shadow to allow reassignment)
+function updateDate(date) {
+  let date = date;
+  date = set(date, { year: 2024 });
+  return date;
+}
+
+// Midnight zeroing
+d = startOfDay(d);
+
+// Timestamp
+d = toDate(1609459200000);
+
+// UTC operations
+d = set(d, { date: 15 }, { in: tz('UTC') });
+
+// Consecutive mutations merged
+d = set(d, { year: 2024, month: 5, date: 15 });
+```
+
+## Automatic Fixes
+
+The rule provides automatic fixes for most common patterns:
+
+### 1. Simple Field Updates → `set()`
+
+```js
+// Before
+d.setHours(14);
+d.setMinutes(30);
+
+// After (auto-fixed)
+d = set(d, { hours: 14 });
+d = set(d, { minutes: 30 });
+```
+
+### 2. Midnight Zeroing → `startOfDay()`
+
+```js
+// Before
+d.setHours(0, 0, 0, 0);
+
+// After (auto-fixed)
+d = startOfDay(d);
+```
+
+### 3. Timestamp → `toDate()`
+
+```js
+// Before
+d.setTime(1609459200000);
+
+// After (auto-fixed)
+d = toDate(1609459200000);
+```
+
+### 4. Arithmetic → `add*` / `sub*` Functions
+
+The rule normalizes arithmetic to the largest fitting unit:
+
+```js
+// Before
+d.setHours(d.getHours() + 48);
+
+// After (auto-fixed, normalized to days)
+d = addDays(d, 2);
+
+// Before
+d.setMonth(d.getMonth() + 6);
+
+// After (auto-fixed, normalized to quarters)
+d = addQuarters(d, 2);
+```
+
+Supported units (with normalization):
+- Milliseconds → Seconds → Minutes → Hours → Days → Weeks
+- Months → Quarters → Years
+
+### 5. UTC Operations
+
+```js
+// Before
+d.setUTCHours(14);
+
+// After (auto-fixed)
+d = set(d, { hours: 14 }, { in: tz('UTC') });
+```
+
+### 6. Consecutive Setters → Merged `set()`
+
+```js
+// Before
+d.setFullYear(2024);
+d.setMonth(5);
+d.setDate(15);
+
+// After (auto-fixed)
+d = set(d, { year: 2024, month: 5, date: 15 });
+```
+
+### 7. Side Effects → Temporary Variables
+
+```js
+// Before
+d.setHours(sideEffect());
+d.setMinutes(anotherEffect());
+
+// After (auto-fixed)
+const __dateFix1 = sideEffect();
+const __dateFix2 = anotherEffect();
+d = set(d, { hours: __dateFix1, minutes: __dateFix2 });
+```
+
+## Suggestions for Ambiguous Cases
+
+Some patterns are ambiguous and cannot be auto-fixed. The rule provides suggestions instead:
+
+### UTC/Local Mismatch
+
+When mixing UTC and local getters/setters, the intent is unclear:
+
+```js
+// Ambiguous: UTC setter with local getter
+d.setUTCHours(d.getHours() + 1);
+
+// Suggestions provided:
+// 1. Use UTC arithmetic (recommended)
+d = addHours(d, 1, { in: tz('UTC') });
+
+// 2. Use local arithmetic
+d = addHours(d, 1);
+```
+
+## Report-Only Cases
+
+### Aliasing
+
+When a date variable has aliases that are read after mutation, converting to immutable would change behavior:
+
+```js
+// Unsafe to auto-fix
+const d = new Date();
+const alias = d;
+d.setHours(5);
+console.log(alias);  // Would see mutated date
+
+// Error reported: alias "alias" is read after mutation
+```
+
+Safe cases (auto-fixed normally):
+
+```js
+// Alias not read after mutation
+const d = new Date();
+const alias = d;
+d.setHours(5);  // ✅ Auto-fixed
+return;
+
+// Alias read before mutation
+let d = new Date();
+const alias = d;
+console.log(alias);  // Read before
+d.setHours(5);  // ✅ Auto-fixed
+```
+
+## Options
+
+This rule has no configuration options.
+
+## When Not To Use It
+
+- If your codebase heavily relies on Date mutation and a full migration is not feasible
+- If you're working with legacy code that requires mutable dates for compatibility
+- If you're not using date-fns in your project (though we highly recommend it!)
+
+## Related Rules
+
+- [`no-bare-date-call`](./no-bare-date-call.md) - Disallows calling `Date()` without `new`
+- [`no-date-constructor-string`](./no-date-constructor-string.md) - Disallows string-based Date construction
+- [`prefer-date-fns-from-epoch`](./prefer-date-fns-from-epoch.md) - Prefers date-fns for epoch timestamps
+
+## Version
+
+This rule was introduced in eslint-plugin-date-fns v0.2.0.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
+    "@date-fns/tz": "^1.0.0",
     "@typescript-eslint/utils": "^8.0.0",
     "date-fns": "^4.0.0"
   },

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,7 @@ These rules prevent common date handling bugs and enforce safe patterns.
 | no-bare-date-call | Forbid bare `Date()` string call | None | `format(new Date(), ...)` patterns | Prevent string coercion | [docs](./docs/rules/no-bare-date-call.md) |
 | no-date-coercion-literals | Forbid `new Date(null)` and `new Date(true/false)` | All cases | None | Safe literal conversion | [docs](./docs/rules/no-date-coercion-literals.md) |
 | no-date-constructor-string | Forbids `new Date(string)` and `Date.parse(string)` | ISO literals to `parseISO()` | Variables get suggestions | Prefer `parseISO` or `parse` | [docs](./docs/rules/no-date-constructor-string.md) |
+| no-date-mutation | Forbid in-place Date mutation (setter methods) | Most cases | UTC/local mismatch | Enforce immutability | [docs](./docs/rules/no-date-mutation.md) |
 | no-legacy-year-components | Forbid `new Date(y, ...)` with `0 ≤ y ≤ 99` (1900+ quirk) | None | 4-digit year via `parseISO()` | Avoid century ambiguity | [docs](./docs/rules/no-legacy-year-components.md) |
 | prefer-date-fns-from-epoch | Prefer `fromUnixTime(sec)` over `new Date(number)` | Numeric literals | Variables get suggestions | Safe epoch conversion | [docs](./docs/rules/prefer-date-fns-from-epoch.md) |
 | prefer-iso-literal-over-components | Replace `new Date(y, m, d, ...)` (all numeric literals) | All-literal calls | Mixed literal/variable calls | UTC ISO format | [docs](./docs/rules/prefer-iso-literal-over-components.md) |

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -12,6 +12,7 @@ const recommendedRules: Linter.RulesRecord = {
   "date-fns/no-bare-date-call": "error",
   "date-fns/no-legacy-year-components": "error",
   "date-fns/require-isvalid-after-parse": "error",
+  "date-fns/no-date-mutation": "error",
 };
 
 export default recommendedRules;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -6,6 +6,7 @@ import noBareDateCall from "./no-bare-date-call/index.js";
 import noLegacyYearComponents from "./no-legacy-year-components/index.js";
 import requireIsvalidAfterParse from "./require-isvalid-after-parse/index.js";
 import noMagicTime from "./no-magic-time/index.js";
+import noDateMutation from "./no-date-mutation/index.js";
 
 /**
  * Registry of all available ESLint rules provided by this plugin.
@@ -19,4 +20,5 @@ export default {
   "no-legacy-year-components": noLegacyYearComponents,
   "require-isvalid-after-parse": requireIsvalidAfterParse,
   "no-magic-time": noMagicTime,
+  "no-date-mutation": noDateMutation,
 };

--- a/src/rules/no-date-mutation/index.ts
+++ b/src/rules/no-date-mutation/index.ts
@@ -1,0 +1,952 @@
+import {
+  ASTUtils,
+  ESLintUtils,
+  type TSESTree,
+  type TSESLint,
+} from "@typescript-eslint/utils";
+import type { TypeChecker } from "typescript";
+import {
+  ensureDateFnsNamedImports,
+  ensureDateFnsTzNamedImports,
+} from "../../utils/imports.js";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/ChristianMurphy/eslint-plugin-date-fns/blob/main/docs/rules/${name}.md`,
+);
+
+type Options = [];
+type MessageIds =
+  | "mutatingDate"
+  | "mutatingDateMismatch"
+  | "mutatingDateUnsafe"
+  | "suggestUTCIntent"
+  | "suggestLocalIntent";
+
+const LOCAL_SETTERS = new Set([
+  "setFullYear",
+  "setMonth",
+  "setDate",
+  "setHours",
+  "setMinutes",
+  "setSeconds",
+  "setMilliseconds",
+  "setYear",
+]);
+
+const UTC_SETTERS = new Set([
+  "setUTCFullYear",
+  "setUTCMonth",
+  "setUTCDate",
+  "setUTCHours",
+  "setUTCMinutes",
+  "setUTCSeconds",
+  "setUTCMilliseconds",
+]);
+
+const ALL_SETTERS = new Set([...LOCAL_SETTERS, ...UTC_SETTERS, "setTime"]);
+
+const SETTER_TO_FIELD: Record<string, string> = {
+  setFullYear: "year",
+  setUTCFullYear: "year",
+  setMonth: "month",
+  setUTCMonth: "month",
+  setDate: "date",
+  setUTCDate: "date",
+  setHours: "hours",
+  setUTCHours: "hours",
+  setMinutes: "minutes",
+  setUTCMinutes: "minutes",
+  setSeconds: "seconds",
+  setUTCSeconds: "seconds",
+  setMilliseconds: "milliseconds",
+  setUTCMilliseconds: "milliseconds",
+};
+
+const GETTER_TO_UNIT: Record<string, string> = {
+  getFullYear: "years",
+  getUTCFullYear: "years",
+  getMonth: "months",
+  getUTCMonth: "months",
+  getDate: "days",
+  getUTCDate: "days",
+  getHours: "hours",
+  getUTCHours: "hours",
+  getMinutes: "minutes",
+  getUTCMinutes: "minutes",
+  getSeconds: "seconds",
+  getUTCSeconds: "seconds",
+  getMilliseconds: "milliseconds",
+  getUTCMilliseconds: "milliseconds",
+};
+
+const UNIT_CONVERSIONS: Array<{ from: string; to: string; factor: number }> = [
+  { from: "months", to: "years", factor: 12 },
+  { from: "quarters", to: "years", factor: 4 },
+  { from: "months", to: "quarters", factor: 3 },
+  { from: "days", to: "weeks", factor: 7 },
+  { from: "hours", to: "days", factor: 24 },
+  { from: "minutes", to: "days", factor: 1440 },
+  { from: "seconds", to: "days", factor: 86_400 },
+  { from: "milliseconds", to: "days", factor: 86_400_000 },
+  { from: "minutes", to: "hours", factor: 60 },
+  { from: "seconds", to: "hours", factor: 3600 },
+  { from: "milliseconds", to: "hours", factor: 3_600_000 },
+  { from: "seconds", to: "minutes", factor: 60 },
+  { from: "milliseconds", to: "minutes", factor: 60_000 },
+  { from: "milliseconds", to: "seconds", factor: 1000 },
+];
+
+/**
+ * Normalizes delta to largest fitting unit using conversion table.
+ */
+function normalizeUnit(
+  delta: number,
+  unit: string,
+): { delta: number; unit: string } {
+  for (const conversion of UNIT_CONVERSIONS) {
+    if (conversion.from === unit && delta % conversion.factor === 0) {
+      return { delta: delta / conversion.factor, unit: conversion.to };
+    }
+  }
+  return { delta, unit };
+}
+
+/**
+ * Detects arithmetic pattern like obj.setX(obj.getX() ± N).
+ */
+function detectArithmetic(
+  call: TSESTree.CallExpression,
+  setterName: string,
+):
+  | { delta: number; unit: string; isUTC: boolean; mismatch?: boolean }
+  | undefined {
+  if (call.arguments.length !== 1) return undefined;
+
+  const argument = call.arguments[0];
+  if (!argument) return undefined;
+  if (argument.type !== "BinaryExpression") return undefined;
+  if (argument.operator !== "+" && argument.operator !== "-") return undefined;
+
+  const left = argument.left;
+  if (left.type !== "CallExpression") return undefined;
+  if (left.callee.type !== "MemberExpression") return undefined;
+  if (left.callee.property.type !== "Identifier") return undefined;
+
+  const getterName = left.callee.property.name;
+  const unit = GETTER_TO_UNIT[getterName];
+  if (!unit) return undefined;
+
+  const isSetterUTC = UTC_SETTERS.has(setterName);
+  const expectedGetter = setterName.replace("set", "get");
+  const isGetterUTC = getterName.startsWith("getUTC");
+
+  const hasMismatch = isSetterUTC !== isGetterUTC;
+  if (!hasMismatch && getterName !== expectedGetter) return undefined;
+
+  if (hasMismatch) {
+    const setterUnit = setterName
+      .replace("set", "")
+      .replace("UTC", "")
+      .toLowerCase();
+    const getterUnit = getterName
+      .replace("get", "")
+      .replace("UTC", "")
+      .toLowerCase();
+    if (setterUnit !== getterUnit) return undefined;
+  }
+
+  const setterReceiver = call.callee;
+  if (setterReceiver.type !== "MemberExpression") return undefined;
+  const setterObject = setterReceiver.object;
+  const getterObject = left.callee.object;
+
+  if (
+    setterObject.type === "Identifier" &&
+    getterObject.type === "Identifier"
+  ) {
+    if (setterObject.name !== getterObject.name) return undefined;
+  } else {
+    return undefined;
+  }
+
+  const right = argument.right;
+  if (right.type !== "Literal" || typeof right.value !== "number")
+    return undefined;
+
+  let delta = right.value;
+  if (argument.operator === "-") delta = -delta;
+
+  return { delta, unit, isUTC: isSetterUTC, mismatch: hasMismatch };
+}
+
+/**
+ * Checks if property name is a Date setter method.
+ */
+function isSetterName(name: string): boolean {
+  return ALL_SETTERS.has(name);
+}
+
+/**
+ * Checks for midnight zeroing pattern: setHours(0, 0, 0, 0) or setUTCHours(0, 0, 0, 0).
+ */
+function isMidnightZeroing(call: TSESTree.CallExpression): boolean {
+  const callee = call.callee;
+  if (
+    callee.type !== "MemberExpression" ||
+    callee.property.type !== "Identifier"
+  ) {
+    return false;
+  }
+
+  const setterName = callee.property.name;
+  if (setterName !== "setHours" && setterName !== "setUTCHours") {
+    return false;
+  }
+
+  if (call.arguments.length !== 4) {
+    return false;
+  }
+
+  return call.arguments.every(
+    (argument) => argument.type === "Literal" && argument.value === 0,
+  );
+}
+
+/**
+ * Checks if expression is a pure Math.* call with no side effects.
+ */
+function isPureMathCall(node: TSESTree.Expression): boolean {
+  if (node.type !== "CallExpression") return false;
+  if (node.callee.type !== "MemberExpression") return false;
+  if (node.callee.object.type !== "Identifier") return false;
+  if (node.callee.object.name !== "Math") return false;
+  return true;
+}
+
+/**
+ * Finds the parent statement node for a given AST node.
+ */
+function findParentStatement(
+  node: TSESTree.Node,
+): TSESTree.Statement | undefined {
+  let current: TSESTree.Node | undefined = node.parent;
+  while (current) {
+    const currentType = current.type;
+    if (
+      currentType === "ExpressionStatement" ||
+      currentType === "VariableDeclaration" ||
+      currentType === "ReturnStatement" ||
+      currentType === "IfStatement" ||
+      currentType === "ForStatement" ||
+      currentType === "WhileStatement"
+    ) {
+      return current;
+    }
+    current = current.parent;
+  }
+  return undefined;
+}
+
+/**
+ * Checks if two call expression nodes are consecutive statements in the same block.
+ */
+function areConsecutiveStatements(
+  node1: TSESTree.CallExpression,
+  node2: TSESTree.CallExpression,
+): boolean {
+  const stmt1 = findParentStatement(node1);
+  const stmt2 = findParentStatement(node2);
+  if (!stmt1 || !stmt2) return false;
+
+  const parent1 = stmt1.parent;
+  const parent2 = stmt2.parent;
+  if (parent1 !== parent2) return false;
+  if (parent1.type !== "Program" && parent1.type !== "BlockStatement")
+    return false;
+
+  const body = parent1.body;
+  const index1 = body.indexOf(stmt1 as TSESTree.Statement);
+  const index2 = body.indexOf(stmt2 as TSESTree.Statement);
+
+  return index2 === index1 + 1;
+}
+
+interface MutationInfo {
+  node: TSESTree.CallExpression;
+  receiver: TSESTree.Expression;
+  receiverText: string;
+  setterName: string;
+  isUTC: boolean;
+  fieldName?: string;
+  argumentText?: string;
+  hasSideEffect?: boolean;
+  tempVarName?: string;
+  type: "midnight" | "timestamp" | "arithmetic" | "field" | "other";
+  arithmeticInfo?: {
+    delta: number;
+    unit: string;
+    functionName: string;
+    tzOption: string;
+  };
+}
+
+/**
+ * Checks if expression has side effects, treating Math.* calls as pure.
+ */
+function hasSideEffects(
+  node: TSESTree.Expression,
+  sourceCode: TSESLint.SourceCode,
+): boolean {
+  if (isPureMathCall(node)) return false;
+
+  if (
+    node.type === "Literal" ||
+    node.type === "TemplateLiteral" ||
+    node.type === "UnaryExpression"
+  ) {
+    return false;
+  }
+
+  return ASTUtils.hasSideEffect(node, sourceCode);
+}
+
+/**
+ * Checks if Date identifier is shadowed by local declaration in node's scope.
+ */
+function isDateShadowedAtNode(
+  node: TSESTree.Node,
+  sourceCode: TSESLint.SourceCode,
+): boolean {
+  const scopeManager = sourceCode.scopeManager;
+  if (!scopeManager) return false;
+
+  for (const scope of scopeManager.scopes) {
+    const dateVariable = scope.variables.find(
+      (variable) => variable.name === "Date",
+    );
+    if (dateVariable && dateVariable.defs.length > 0 && scope.block.range) {
+      const [scopeStart, scopeEnd] = scope.block.range;
+      const [nodeStart, nodeEnd] = node.range;
+
+      if (nodeStart >= scopeStart && nodeEnd <= scopeEnd) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Checks if expression is of Date type using TypeScript type information or heuristics.
+ */
+function isDateType(
+  node: TSESTree.Expression,
+  checker: TypeChecker | undefined,
+  parserServices:
+    | NonNullable<TSESLint.SourceCode["parserServices"]>
+    | undefined,
+  sourceCode: TSESLint.SourceCode,
+): boolean {
+  if (isDateShadowedAtNode(node, sourceCode)) {
+    return false;
+  }
+
+  if (checker && parserServices?.esTreeNodeToTSNodeMap) {
+    try {
+      const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node);
+      if (tsNode) {
+        const type = checker.getTypeAtLocation(tsNode);
+        const typeString = checker.typeToString(type);
+        const isDate = typeString === "Date" || /\bDate\b/.test(typeString);
+        return isDate;
+      }
+    } catch {
+      // Fall through to heuristics
+    }
+  }
+
+  if (node.type === "NewExpression") {
+    const callee = node.callee;
+    if (callee.type === "Identifier" && callee.name === "Date") {
+      return !isDateShadowedAtNode(node, sourceCode);
+    }
+    return (
+      callee.type === "MemberExpression" &&
+      callee.object.type === "Identifier" &&
+      callee.object.name === "globalThis" &&
+      callee.property.type === "Identifier" &&
+      callee.property.name === "Date"
+    );
+  }
+
+  if (node.type === "Identifier") {
+    return false;
+  }
+
+  return false;
+}
+
+/**
+ * Checks if receiver has aliases that are read after the mutation point.
+ */
+function hasAliasReadAfterMutation(
+  mutationNode: TSESTree.CallExpression,
+  receiver: TSESTree.Expression,
+  sourceCode: TSESLint.SourceCode,
+): { hasAlias: boolean; aliasName?: string } {
+  if (receiver.type !== "Identifier") {
+    return { hasAlias: false };
+  }
+
+  const receiverName = receiver.name;
+  const scopeManager = sourceCode.scopeManager;
+  if (!scopeManager) return { hasAlias: false };
+
+  const mutationPosition = mutationNode.range[0];
+
+  for (const scope of scopeManager.scopes) {
+    for (const variable of scope.variables) {
+      if (variable.name === receiverName) continue;
+
+      for (const definition of variable.defs) {
+        if (
+          definition.type === "Variable" &&
+          definition.node.type === "VariableDeclarator"
+        ) {
+          const init = definition.node.init;
+          if (
+            init &&
+            init.type === "Identifier" &&
+            init.name === receiverName
+          ) {
+            for (const reference of variable.references) {
+              if (
+                reference.isRead() &&
+                reference.identifier.range[0] > mutationPosition
+              ) {
+                return { hasAlias: true, aliasName: variable.name };
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return { hasAlias: false };
+}
+
+export default createRule<Options, MessageIds>({
+  name: "no-date-mutation",
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow in-place Date mutation. Prefer immutable date-fns alternatives.",
+    },
+    fixable: "code",
+    hasSuggestions: true,
+    schema: [],
+    messages: {
+      mutatingDate:
+        "Avoid mutating Date in place. Rewritten to immutable date-fns usage.",
+      mutatingDateMismatch:
+        "Date mutation has unclear intent ({{reason}}). Review suggestions to clarify.",
+      mutatingDateUnsafe: "Cannot autofix Date mutation - {{reason}}.",
+      suggestUTCIntent: "Use UTC arithmetic (primary suggestion)",
+      suggestLocalIntent: "Use local arithmetic",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const sourceCode = context.sourceCode;
+    const parserServices = context.sourceCode.parserServices;
+    const checker = parserServices?.program?.getTypeChecker?.();
+
+    const mutations: MutationInfo[] = [];
+    let dateFixCounter = 0;
+
+    function generateTemporaryVariableName(): string {
+      dateFixCounter++;
+      return `__dateFix${dateFixCounter}`;
+    }
+
+    return {
+      CallExpression(node: TSESTree.CallExpression) {
+        if (node.callee.type !== "MemberExpression") return;
+
+        const { property } = node.callee;
+        if (property.type !== "Identifier") return;
+        if (!isSetterName(property.name)) return;
+
+        if (node.callee.optional || node.optional) return;
+
+        const receiver = node.callee.object;
+        if (!isDateType(receiver, checker, parserServices, sourceCode)) return;
+
+        const aliasCheck = hasAliasReadAfterMutation(
+          node,
+          receiver,
+          sourceCode,
+        );
+        if (aliasCheck.hasAlias) {
+          context.report({
+            node,
+            messageId: "mutatingDateUnsafe",
+            data: {
+              reason: `alias "${aliasCheck.aliasName}" is read after mutation - changing to immutable would alter behavior`,
+            },
+          });
+          return;
+        }
+
+        const setterName = property.name;
+        const isUTC = UTC_SETTERS.has(setterName);
+        const receiverText = sourceCode.getText(receiver);
+
+        if (isMidnightZeroing(node)) {
+          mutations.push({
+            node,
+            receiver,
+            receiverText,
+            setterName,
+            isUTC,
+            type: "midnight",
+          });
+          return;
+        }
+
+        if (setterName === "setTime" && node.arguments.length === 1) {
+          mutations.push({
+            node,
+            receiver,
+            receiverText,
+            setterName,
+            isUTC,
+            type: "timestamp",
+            argumentText: sourceCode.getText(node.arguments[0]),
+          });
+          return;
+        }
+
+        const arithmetic = detectArithmetic(node, setterName);
+        if (arithmetic) {
+          if (arithmetic.mismatch) {
+            const normalized = normalizeUnit(arithmetic.delta, arithmetic.unit);
+            const isAddition = normalized.delta > 0;
+            const absoluteDelta = Math.abs(normalized.delta);
+            const capitalizedUnit =
+              normalized.unit.charAt(0).toUpperCase() +
+              normalized.unit.slice(1);
+            const functionName = isAddition
+              ? `add${capitalizedUnit}`
+              : `sub${capitalizedUnit}`;
+
+            context.report({
+              node,
+              messageId: "mutatingDateMismatch",
+              data: {
+                reason: "UTC setter with local getter - intent unclear",
+              },
+              suggest: [
+                {
+                  messageId: "suggestUTCIntent",
+                  fix(fixer) {
+                    const fixes: TSESLint.RuleFix[] = [];
+                    const tzImportFix = ensureDateFnsTzNamedImports(
+                      context,
+                      fixer,
+                      [functionName, "tz"],
+                    );
+                    if (tzImportFix) fixes.unshift(tzImportFix);
+                    fixes.push(
+                      fixer.replaceText(
+                        node,
+                        `${receiverText} = ${functionName}(${receiverText}, ${absoluteDelta}, { in: tz('UTC') })`,
+                      ),
+                    );
+                    return fixes;
+                  },
+                },
+                {
+                  messageId: "suggestLocalIntent",
+                  fix(fixer) {
+                    const fixes: TSESLint.RuleFix[] = [];
+                    const dateFnsImportFix = ensureDateFnsNamedImports(
+                      context,
+                      fixer,
+                      [functionName],
+                    );
+                    if (dateFnsImportFix) fixes.unshift(dateFnsImportFix);
+                    fixes.push(
+                      fixer.replaceText(
+                        node,
+                        `${receiverText} = ${functionName}(${receiverText}, ${absoluteDelta})`,
+                      ),
+                    );
+                    return fixes;
+                  },
+                },
+              ],
+            });
+            return;
+          }
+
+          const normalized = normalizeUnit(arithmetic.delta, arithmetic.unit);
+          const isAddition = normalized.delta > 0;
+          const absoluteDelta = Math.abs(normalized.delta);
+          const capitalizedUnit =
+            normalized.unit.charAt(0).toUpperCase() + normalized.unit.slice(1);
+          const functionName = isAddition
+            ? `add${capitalizedUnit}`
+            : `sub${capitalizedUnit}`;
+          const tzOption = arithmetic.isUTC ? `, { in: tz('UTC') }` : "";
+
+          // No ambiguity detected, collect for normal processing
+          mutations.push({
+            node,
+            receiver,
+            receiverText,
+            setterName,
+            isUTC: arithmetic.isUTC,
+            type: "arithmetic",
+            arithmeticInfo: {
+              delta: absoluteDelta,
+              unit: normalized.unit,
+              functionName,
+              tzOption,
+            },
+          });
+          return;
+        }
+        const fieldName = SETTER_TO_FIELD[setterName];
+        if (fieldName && node.arguments.length > 0) {
+          const argument = node.arguments[0];
+          if (!argument) return;
+          if (argument.type === "SpreadElement") return;
+
+          mutations.push({
+            node,
+            receiver,
+            receiverText,
+            setterName,
+            isUTC,
+            type: "field",
+            fieldName,
+            argumentText: sourceCode.getText(argument),
+            hasSideEffect: hasSideEffects(argument, sourceCode),
+          });
+          return;
+        }
+
+        mutations.push({
+          node,
+          receiver,
+          receiverText,
+          setterName,
+          isUTC,
+          type: "other",
+        });
+      },
+
+      "Program:exit"() {
+        dateFixCounter = 0;
+        for (const mutation of mutations) {
+          if (mutation.type === "field" && mutation.hasSideEffect) {
+            mutation.tempVarName = generateTemporaryVariableName();
+          }
+        }
+
+        const processedIndices = new Set<number>();
+
+        for (let index = 0; index < mutations.length; index++) {
+          if (processedIndices.has(index)) continue;
+
+          const mutation = mutations[index];
+          if (!mutation) continue;
+
+          if (mutation.type !== "field") {
+            reportSingleMutation(mutation);
+            processedIndices.add(index);
+            continue;
+          }
+
+          const group: MutationInfo[] = [mutation];
+          let nextIndex = index + 1;
+
+          while (nextIndex < mutations.length) {
+            const next = mutations[nextIndex];
+            if (!next) {
+              nextIndex++;
+              continue;
+            }
+
+            if (processedIndices.has(nextIndex)) {
+              nextIndex++;
+              continue;
+            }
+
+            const lastInGroup = group.at(-1);
+            if (
+              lastInGroup &&
+              next.type === "field" &&
+              next.receiverText === mutation.receiverText &&
+              next.isUTC === mutation.isUTC &&
+              areConsecutiveStatements(lastInGroup.node, next.node)
+            ) {
+              group.push(next);
+              processedIndices.add(nextIndex);
+              nextIndex++;
+            } else {
+              break;
+            }
+          }
+
+          if (group.length > 1) {
+            reportMergedMutations(group);
+          } else {
+            reportSingleMutation(mutation);
+          }
+          processedIndices.add(index);
+        }
+      },
+    };
+
+    function reportSingleMutation(mutation: MutationInfo) {
+      const { node, receiverText, isUTC, type } = mutation;
+
+      if (type === "midnight") {
+        const tzOption = isUTC ? `, { in: tz('UTC') }` : "";
+        context.report({
+          node,
+          messageId: "mutatingDate",
+          fix(fixer) {
+            const fixes: TSESLint.RuleFix[] = [];
+            const dateFnsImportFix = ensureDateFnsNamedImports(context, fixer, [
+              "startOfDay",
+            ]);
+            if (dateFnsImportFix) fixes.unshift(dateFnsImportFix);
+            if (isUTC) {
+              const tzImportFix = ensureDateFnsTzNamedImports(context, fixer, [
+                "tz",
+              ]);
+              if (tzImportFix) fixes.unshift(tzImportFix);
+            }
+            fixes.push(
+              fixer.replaceText(
+                node,
+                `${receiverText} = startOfDay(${receiverText}${tzOption})`,
+              ),
+            );
+            return fixes;
+          },
+        });
+      } else if (type === "timestamp") {
+        context.report({
+          node,
+          messageId: "mutatingDate",
+          fix(fixer) {
+            const fixes: TSESLint.RuleFix[] = [];
+            const importFix = ensureDateFnsNamedImports(context, fixer, [
+              "toDate",
+            ]);
+            if (importFix) fixes.unshift(importFix);
+            fixes.push(
+              fixer.replaceText(
+                node,
+                `${receiverText} = toDate(${mutation.argumentText})`,
+              ),
+            );
+            return fixes;
+          },
+        });
+      } else if (type === "arithmetic" && mutation.arithmeticInfo) {
+        const { functionName, delta, tzOption } = mutation.arithmeticInfo;
+        context.report({
+          node,
+          messageId: "mutatingDate",
+          fix(fixer) {
+            const fixes: TSESLint.RuleFix[] = [];
+            if (isUTC) {
+              const tzImportFix = ensureDateFnsTzNamedImports(context, fixer, [
+                "tz",
+              ]);
+              if (tzImportFix) fixes.unshift(tzImportFix);
+            }
+            const dateFnsImportFix = ensureDateFnsNamedImports(context, fixer, [
+              functionName,
+            ]);
+            if (dateFnsImportFix) fixes.unshift(dateFnsImportFix);
+            fixes.push(
+              fixer.replaceText(
+                node,
+                `${receiverText} = ${functionName}(${receiverText}, ${delta}${tzOption})`,
+              ),
+            );
+            return fixes;
+          },
+        });
+      } else if (type === "field") {
+        const tzOption = isUTC ? `, { in: tz('UTC') }` : "";
+
+        // Phase 4b: Use pre-assigned temp variable if argument has side effects
+        const temporaryVariableName = mutation.tempVarName; // Pre-assigned in Program:exit
+        const effectiveArgumentText =
+          temporaryVariableName || mutation.argumentText;
+
+        context.report({
+          node,
+          messageId: "mutatingDate",
+          fix(fixer) {
+            const fixes: TSESLint.RuleFix[] = [];
+            const dateFnsImportFix = ensureDateFnsNamedImports(context, fixer, [
+              "set",
+            ]);
+            if (dateFnsImportFix) fixes.unshift(dateFnsImportFix);
+            if (isUTC) {
+              const tzImportFix = ensureDateFnsTzNamedImports(context, fixer, [
+                "tz",
+              ]);
+              if (tzImportFix) fixes.unshift(tzImportFix);
+            }
+
+            const setCall = `${receiverText} = set(${receiverText}, { ${mutation.fieldName}: ${effectiveArgumentText} }${tzOption})`;
+            const replacementText = temporaryVariableName
+              ? `const ${temporaryVariableName} = ${mutation.argumentText}; ${setCall}`
+              : setCall;
+
+            fixes.push(fixer.replaceText(node, replacementText));
+            return fixes;
+          },
+        });
+      } else {
+        context.report({
+          node,
+          messageId: "mutatingDate",
+        });
+      }
+    }
+
+    function reportMergedMutations(group: MutationInfo[]) {
+      // All should be field type with same receiver and UTC mode
+      const first = group[0];
+      if (!first) return;
+
+      const receiverText = first.receiverText;
+      const isUTC = first.isUTC;
+      const tzOption = isUTC ? `, { in: tz('UTC') }` : "";
+
+      // Phase 4b: Use pre-assigned temp variables for side effects
+      const temporaryVariableMap = new Map<string, string>(); // maps argumentText to temp var name
+      const mutationsWithTemps = group.map((m) => {
+        if (m.tempVarName && m.argumentText) {
+          // Use pre-assigned temp var name (assigned in Program:exit)
+          temporaryVariableMap.set(m.argumentText, m.tempVarName);
+          return {
+            ...m,
+            effectiveArgumentText: m.tempVarName,
+          };
+        }
+        return {
+          ...m,
+          effectiveArgumentText: m.argumentText || "",
+        };
+      });
+
+      const fields = mutationsWithTemps
+        .map((m) => `${m.fieldName}: ${m.effectiveArgumentText}`)
+        .join(", ");
+
+      const temporaryVariableDeclarations = [...temporaryVariableMap.entries()]
+        .map(
+          ([argumentText, temporaryVariable]) =>
+            `const ${temporaryVariable} = ${argumentText};`,
+        )
+        .join("\n");
+
+      for (const [index, mutation] of group.entries()) {
+        if (!mutation) continue;
+
+        if (index === 0) {
+          context.report({
+            node: mutation.node,
+            messageId: "mutatingDate",
+            fix(fixer) {
+              const fixes: TSESLint.RuleFix[] = [];
+
+              if (isUTC) {
+                const tzImportFix = ensureDateFnsTzNamedImports(
+                  context,
+                  fixer,
+                  ["tz"],
+                );
+                if (tzImportFix) fixes.unshift(tzImportFix);
+              }
+              const dateFnsImportFix = ensureDateFnsNamedImports(
+                context,
+                fixer,
+                ["set"],
+              );
+              if (dateFnsImportFix) fixes.unshift(dateFnsImportFix);
+
+              let firstStmt: TSESTree.Node | undefined = mutation.node.parent;
+              while (firstStmt && firstStmt.type !== "ExpressionStatement") {
+                firstStmt = firstStmt.parent;
+              }
+
+              const setCall = `${receiverText} = set(${receiverText}, { ${fields} }${tzOption});`;
+              const replacementText =
+                temporaryVariableDeclarations.length > 0
+                  ? `${temporaryVariableDeclarations}\n${setCall}`
+                  : setCall;
+
+              if (firstStmt && group.length > 1) {
+                const [start, end] = firstStmt.range;
+                const text = sourceCode.getText();
+                const hasTrailingNewline =
+                  end < text.length && text[end] === "\n";
+                const rangeEnd = hasTrailingNewline ? end + 1 : end;
+                fixes.push(
+                  fixer.replaceTextRange([start, rangeEnd], replacementText),
+                );
+              } else {
+                fixes.push(fixer.replaceText(mutation.node, replacementText));
+              }
+
+              for (
+                let mutationIndex = 1;
+                mutationIndex < group.length;
+                mutationIndex++
+              ) {
+                const nextMutation = group[mutationIndex];
+                if (!nextMutation) continue;
+
+                let stmt: TSESTree.Node | undefined = nextMutation.node.parent;
+                while (stmt && stmt.type !== "ExpressionStatement") {
+                  stmt = stmt.parent;
+                }
+                if (stmt) {
+                  const [start, end] = stmt.range;
+                  const text = sourceCode.getText();
+                  const hasTrailingNewline =
+                    end < text.length && text[end] === "\n";
+                  const rangeEnd = hasTrailingNewline ? end + 1 : end;
+                  fixes.push(fixer.removeRange([start, rangeEnd]));
+                }
+              }
+
+              return fixes;
+            },
+          });
+        } else {
+          context.report({
+            node: mutation.node,
+            messageId: "mutatingDate",
+          });
+        }
+      }
+    }
+  },
+});

--- a/src/rules/require-isvalid-after-parse/index.ts
+++ b/src/rules/require-isvalid-after-parse/index.ts
@@ -324,9 +324,12 @@ export default createRule<Options, MessageIds>({
               data: { id: identifierName, call: callText },
               fix(fixer): TSESLint.RuleFix[] {
                 const fixes: TSESLint.RuleFix[] = [];
-                fixes.push(
-                  ensureDateFnsNamedImports(context, fixer, ["isValid"]),
-                );
+                const importFix = ensureDateFnsNamedImports(context, fixer, [
+                  "isValid",
+                ]);
+                if (importFix) {
+                  fixes.push(importFix);
+                }
                 const newText = `const ${identifierName} = ${callText};
 if (!isValid(${identifierName})) {
   // TODO: handle invalid date

--- a/src/utils/date-call.ts
+++ b/src/utils/date-call.ts
@@ -7,7 +7,7 @@ import {
 import { getNodeRange } from "./types.js";
 
 /**
- * Detects Date constructor patterns including globalThis.Date.
+ * Detects Date constructor patterns including globalThis.Date and globalThis['Date'].
  */
 export function isNewDateSyntax(node: TSESTree.NewExpression): boolean {
   const { callee } = node;
@@ -17,12 +17,24 @@ export function isNewDateSyntax(node: TSESTree.NewExpression): boolean {
   if (ASTUtils.isNodeOfType(AST_NODE_TYPES.MemberExpression)(callee)) {
     const object = callee.object;
     const property = callee.property;
-    return (
+    // Check for globalThis.Date (dot notation)
+    if (
       ASTUtils.isNodeOfType(AST_NODE_TYPES.Identifier)(object) &&
       object.name === "globalThis" &&
       ASTUtils.isNodeOfType(AST_NODE_TYPES.Identifier)(property) &&
       property.name === "Date"
-    );
+    ) {
+      return true;
+    }
+    // Check for globalThis['Date'] (computed property with string literal)
+    if (
+      ASTUtils.isNodeOfType(AST_NODE_TYPES.Identifier)(object) &&
+      object.name === "globalThis" &&
+      ASTUtils.isNodeOfType(AST_NODE_TYPES.Literal)(property) &&
+      property.value === "Date"
+    ) {
+      return true;
+    }
   }
   return false;
 }

--- a/src/utils/fixers.ts
+++ b/src/utils/fixers.ts
@@ -14,8 +14,10 @@ export function createImportAndReplaceFix<
   node: TSESTree.Node,
   replacement: string,
 ): TSESLint.RuleFix[] {
-  return [
-    ensureDateFnsNamedImports(context, fixer, imports),
-    fixer.replaceText(node, replacement),
-  ];
+  const importFix = ensureDateFnsNamedImports(context, fixer, imports);
+  const fixes = [fixer.replaceText(node, replacement)];
+  if (importFix) {
+    fixes.unshift(importFix);
+  }
+  return fixes;
 }

--- a/src/utils/imports.ts
+++ b/src/utils/imports.ts
@@ -2,75 +2,180 @@ import type { TSESLint, TSESTree } from "@typescript-eslint/utils";
 
 /**
  * Creates ESLint fix to ensure date-fns named imports are available.
+ * Merges new imports into existing date-fns import or creates new import.
  */
 export function ensureDateFnsNamedImports(
   context: Readonly<TSESLint.RuleContext<string, unknown[]>>,
   fixer: TSESLint.RuleFixer,
   names: string[],
-): TSESLint.RuleFix {
+): TSESLint.RuleFix | undefined {
   const sourceCode = context.getSourceCode();
   const program = sourceCode.ast;
+
+  // Find all date-fns imports (only named imports)
   const existing = (program.body as TSESTree.Node[]).filter(
     (nodeToCheck): nodeToCheck is TSESTree.ImportDeclaration =>
       nodeToCheck.type === "ImportDeclaration" &&
-      nodeToCheck.source.value === "date-fns",
+      nodeToCheck.source.value === "date-fns" &&
+      nodeToCheck.specifiers.some((spec) => spec.type === "ImportSpecifier"),
   );
 
-  // Check which names are already imported
+  // Deduplicate and sort input names alphabetically
+  const uniqueNames = [...new Set(names)];
+  uniqueNames.sort();
+
+  // Collect existing imported names
   const existingNames = new Set<string>();
   for (const importNode of existing) {
-    if (importNode.specifiers) {
-      for (const spec of importNode.specifiers) {
-        if (
-          spec.type === "ImportSpecifier" &&
-          spec.imported.type === "Identifier"
-        ) {
-          existingNames.add(spec.imported.name);
-        }
+    for (const spec of importNode.specifiers) {
+      if (
+        spec.type === "ImportSpecifier" &&
+        spec.imported.type === "Identifier"
+      ) {
+        existingNames.add(spec.imported.name);
       }
     }
   }
 
   // Filter out already imported names
-  const newNames = names.filter((name) => !existingNames.has(name));
+  const newNames = uniqueNames.filter(
+    (name: string) => !existingNames.has(name),
+  );
 
-  // If no new imports needed, return a no-op fix
+  // If no new imports needed, return undefined (no fix)
   if (newNames.length === 0) {
-    return fixer.insertTextAfterRange([0, 0], "");
+    return undefined;
   }
 
-  const importText =
-    newNames.length === 1
-      ? `import { ${newNames[0]} } from 'date-fns';`
-      : `import { ${newNames.join(", ")} } from 'date-fns';`;
-
+  // If there's an existing named import from date-fns, merge into the first one
   if (existing.length > 0) {
-    const last = existing.at(-1);
-    if (!last)
-      throw new Error("Array.at() returned undefined despite positive length");
-
-    // Check if there's code on the same line after this import
-    const lastImportEnd = last.range[1];
-    const sourceText = sourceCode.getText();
-    const restOfLine = sourceText.slice(lastImportEnd).match(/^[^\n\r]*/) ?? [
-      "",
-    ];
-    const restOfLineText = restOfLine[0];
-
-    if (restOfLineText.trim() === "") {
-      return fixer.insertTextAfter(last, `\n${importText}`);
-    } else {
-      const leadingWhitespace = restOfLineText.match(/^\s*/)?.[0] ?? "";
-      return fixer.replaceTextRange(
-        [lastImportEnd, lastImportEnd + leadingWhitespace.length],
-        `\n${importText}\n`,
+    const firstImport = existing[0];
+    if (!firstImport) {
+      throw new Error(
+        "Array access returned undefined despite positive length",
       );
     }
+
+    // Get all existing named import specifiers
+    const existingSpecifiers = firstImport.specifiers
+      .filter(
+        (spec): spec is TSESTree.ImportSpecifier =>
+          spec.type === "ImportSpecifier",
+      )
+      .map((spec) =>
+        spec.imported.type === "Identifier"
+          ? spec.imported.name
+          : spec.imported.value,
+      );
+
+    // Combine and sort all names alphabetically
+    const allNames = [...existingSpecifiers, ...newNames];
+    allNames.sort();
+
+    // Build new import statement
+    const newImportText = `import { ${allNames.join(", ")} } from 'date-fns';`;
+
+    return fixer.replaceText(firstImport, newImportText);
   }
+
+  // No existing date-fns imports - create new import at top
+  const importText = `import { ${newNames.join(", ")} } from 'date-fns';`;
 
   const firstNode = program.body[0];
   if (firstNode) {
     return fixer.insertTextBefore(firstNode, `${importText}\n`);
   }
+
+  // Empty file - add at start
+  return fixer.insertTextAfterRange([0, 0], `${importText}\n`);
+}
+
+/**
+ * Creates ESLint fix to ensure @date-fns/tz named imports are available.
+ * Merges new imports into existing @date-fns/tz import or creates new import.
+ */
+export function ensureDateFnsTzNamedImports(
+  context: Readonly<TSESLint.RuleContext<string, unknown[]>>,
+  fixer: TSESLint.RuleFixer,
+  names: string[],
+): TSESLint.RuleFix | undefined {
+  const sourceCode = context.getSourceCode();
+  const program = sourceCode.ast;
+
+  // Find all @date-fns/tz imports (only named imports)
+  const existing = (program.body as TSESTree.Node[]).filter(
+    (nodeToCheck): nodeToCheck is TSESTree.ImportDeclaration =>
+      nodeToCheck.type === "ImportDeclaration" &&
+      nodeToCheck.source.value === "@date-fns/tz" &&
+      nodeToCheck.specifiers.some((spec) => spec.type === "ImportSpecifier"),
+  );
+
+  // Deduplicate and sort input names alphabetically
+  const uniqueNames = [...new Set(names)];
+  uniqueNames.sort();
+
+  // Collect existing imported names
+  const existingNames = new Set<string>();
+  for (const importNode of existing) {
+    for (const spec of importNode.specifiers) {
+      if (
+        spec.type === "ImportSpecifier" &&
+        spec.imported.type === "Identifier"
+      ) {
+        existingNames.add(spec.imported.name);
+      }
+    }
+  }
+
+  // Filter out already imported names
+  const newNames = uniqueNames.filter(
+    (name: string) => !existingNames.has(name),
+  );
+
+  // If no new imports needed, return undefined (no fix)
+  if (newNames.length === 0) {
+    return undefined;
+  }
+
+  // If there's an existing named import from @date-fns/tz, merge into the first one
+  if (existing.length > 0) {
+    const firstImport = existing[0];
+    if (!firstImport) {
+      throw new Error(
+        "Array access returned undefined despite positive length",
+      );
+    }
+
+    // Get all existing named import specifiers
+    const existingSpecifiers = firstImport.specifiers
+      .filter(
+        (spec): spec is TSESTree.ImportSpecifier =>
+          spec.type === "ImportSpecifier",
+      )
+      .map((spec) =>
+        spec.imported.type === "Identifier"
+          ? spec.imported.name
+          : spec.imported.value,
+      );
+
+    // Combine and sort all names alphabetically
+    const allNames = [...existingSpecifiers, ...newNames];
+    allNames.sort();
+
+    // Build new import statement
+    const newImportText = `import { ${allNames.join(", ")} } from '@date-fns/tz';`;
+
+    return fixer.replaceText(firstImport, newImportText);
+  }
+
+  // No existing @date-fns/tz imports - create new import at top
+  const importText = `import { ${newNames.join(", ")} } from '@date-fns/tz';`;
+
+  const firstNode = program.body[0];
+  if (firstNode) {
+    return fixer.insertTextBefore(firstNode, `${importText}\n`);
+  }
+
+  // Empty file - add at start
   return fixer.insertTextAfterRange([0, 0], `${importText}\n`);
 }

--- a/test/rules/no-bare-date-call.test.ts
+++ b/test/rules/no-bare-date-call.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
-import { tester } from "./_setup.ts";
-import rule from "../dist/rules/no-bare-date-call/index.js";
+import { tester } from "../_setup.ts";
+import rule from "../../dist/rules/no-bare-date-call/index.js";
 
 // Test cases for no-bare-date-call rule
 // Focuses on preventing Date() string coercion and suggesting format() alternatives
@@ -171,7 +171,7 @@ test("no-bare-date-call", () => {
             suggestions: [
               {
                 messageId: "suggestFormat",
-                output: `import { addDays } from 'date-fns';\nimport { format } from 'date-fns';\nconst s = format(new Date(), 'yyyy-MM-dd');`,
+                output: `import { addDays, format } from 'date-fns'; const s = format(new Date(), 'yyyy-MM-dd');`,
               },
             ],
           },

--- a/test/rules/no-date-coercion-literals.test.ts
+++ b/test/rules/no-date-coercion-literals.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
-import { tester } from "./_setup.ts";
-import rule from "../dist/rules/no-date-coercion-literals/index.js";
+import { tester } from "../_setup.ts";
+import rule from "../../dist/rules/no-date-coercion-literals/index.js";
 
 // Test cases for no-date-coercion-literals rule
 // Tests prevention of boolean and null literal coercion in Date constructor
@@ -79,12 +79,12 @@ test("no-date-coercion-literals", () => {
       // ❌ Import integration - existing date-fns imports
       {
         code: `import { format } from 'date-fns'; const d = new Date(null);`,
-        output: `import { format } from 'date-fns';\nimport { parseISO } from 'date-fns';\nconst d = parseISO('1970-01-01T00:00:00Z');`,
+        output: `import { format, parseISO } from 'date-fns'; const d = parseISO('1970-01-01T00:00:00Z');`,
         errors: [{ messageId: "noNull", suggestions: [] }],
       },
       {
         code: `import { addDays } from 'date-fns'; const d = new Date(true);`,
-        output: `import { addDays } from 'date-fns';\nimport { parseISO } from 'date-fns';\nconst d = parseISO('1970-01-01T00:00:00.001Z');`,
+        output: `import { addDays, parseISO } from 'date-fns'; const d = parseISO('1970-01-01T00:00:00.001Z');`,
         errors: [{ messageId: "noTrue", suggestions: [] }],
       },
 

--- a/test/rules/no-date-constructor-string.test.ts
+++ b/test/rules/no-date-constructor-string.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
-import { tester } from "./_setup.ts";
-import rule from "../dist/rules/no-date-constructor-string/index.js";
+import { tester } from "../_setup.ts";
+import rule from "../../dist/rules/no-date-constructor-string/index.js";
 
 // Test cases for no-date-constructor-string rule
 // Tests string literal autofixes, variable suggestions, and edge cases

--- a/test/rules/no-date-mutation.test.ts
+++ b/test/rules/no-date-mutation.test.ts
@@ -1,0 +1,572 @@
+import test from "node:test";
+import { tester } from "../_setup.ts";
+import rule from "../../dist/rules/no-date-mutation/index.js";
+
+test("no-date-mutation: valid cases", () => {
+  tester.run("no-date-mutation", rule, {
+    valid: [
+      // date-fns usage - should NOT trigger
+      `import { set } from 'date-fns'; let d = new Date(); d = set(d, { hours: 14 });`,
+      `import { addMonths } from 'date-fns'; let d = new Date(); d = addMonths(d, 1);`,
+      `import { startOfDay } from 'date-fns'; let d = new Date(); d = startOfDay(d);`,
+
+      // Non-Date objects with setters
+      `class MyClass { setHours(h: number) {} } const obj = new MyClass(); obj.setHours(5);`,
+      `const obj = { setHours: (h: number) => {} }; obj.setHours(5);`,
+
+      // Shadowed Date
+      `function demo() { const Date = class {}; const d = new Date(); d.setHours(5); }`,
+      `{ const Date = class {}; const d = new Date(); d.setHours(5); }`,
+
+      // Getters only (no mutation)
+      `const d = new Date(); const h = d.getHours();`,
+      `const d = new Date(); const m = d.getMonth();`,
+      `const d = new Date(); console.log(d.getTime());`,
+
+      // Optional chaining (not handled yet)
+      `declare const d: Date | null; d?.setHours(5);`,
+    ],
+    invalid: [],
+  });
+});
+
+test("no-date-mutation: basic detection", () => {
+  tester.run("no-date-mutation", rule, {
+    valid: [],
+    invalid: [
+      // Legacy setYear - not yet handled
+      {
+        code: `let d = new Date(); d.setYear(2024);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Arithmetic patterns (optimized to add*/sub*)
+      {
+        code: `let d = new Date(); d.setHours(d.getHours() + 1);`,
+        output: `import { addHours } from 'date-fns';\nlet d = new Date(); d = addHours(d, 1);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+      {
+        code: `let d = new Date(); d.setDate(d.getDate() - 7);`,
+        output: `import { subWeeks } from 'date-fns';\nlet d = new Date(); d = subWeeks(d, 1);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+      {
+        code: `let d = new Date(); d.setMonth(d.getMonth() + 1);`,
+        output: `import { addMonths } from 'date-fns';\nlet d = new Date(); d = addMonths(d, 1);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Consecutive setters - merged into single set() call
+      {
+        code: `let d = new Date();\nd.setFullYear(2024);\nd.setMonth(5);\nd.setDate(15);`,
+        output: `import { set } from 'date-fns';\nlet d = new Date();\nd = set(d, { year: 2024, month: 5, date: 15 });`,
+        errors: [
+          { messageId: "mutatingDate" },
+          { messageId: "mutatingDate" },
+          { messageId: "mutatingDate" },
+        ],
+      },
+
+      // With identifier (fixed with type info)
+      {
+        code: `declare const d: Date; d.setHours(5);`,
+        output: `import { set } from 'date-fns';\ndeclare const d: Date; d = set(d, { hours: 5 });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // globalThis.Date (fixed)
+      {
+        code: `let d = new globalThis.Date(); d.setHours(5);`,
+        output: `import { set } from 'date-fns';\nlet d = new globalThis.Date(); d = set(d, { hours: 5 });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Multiple arguments with setFullYear (takes only first argument for now)
+      // Future enhancement: Handle additional arguments (month, date)
+      {
+        code: `let d = new Date(); d.setFullYear(2024, 5, 15);`,
+        output: `import { set } from 'date-fns';\nlet d = new Date(); d = set(d, { year: 2024 });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+    ],
+  });
+});
+
+test("no-date-mutation: simple field updates", () => {
+  tester.run("no-date-mutation", rule, {
+    valid: [],
+    invalid: [
+      // Simple field updates → set()
+      {
+        code: `let d = new Date(); d.setHours(14);`,
+        output: `import { set } from 'date-fns';\nlet d = new Date(); d = set(d, { hours: 14 });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+      {
+        code: `let d = new Date(); d.setMinutes(30);`,
+        output: `import { set } from 'date-fns';\nlet d = new Date(); d = set(d, { minutes: 30 });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+      {
+        code: `let d = new Date(); d.setSeconds(45);`,
+        output: `import { set } from 'date-fns';\nlet d = new Date(); d = set(d, { seconds: 45 });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+      {
+        code: `let d = new Date(); d.setMilliseconds(500);`,
+        output: `import { set } from 'date-fns';\nlet d = new Date(); d = set(d, { milliseconds: 500 });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+      {
+        code: `const d = new Date(); d.setFullYear(2024);`,
+        output: `import { set } from 'date-fns';\nconst d = new Date(); d = set(d, { year: 2024 });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+      {
+        code: `let d = new Date(); d.setMonth(5);`,
+        output: `import { set } from 'date-fns';\nlet d = new Date(); d = set(d, { month: 5 });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+      {
+        code: `let d = new Date(); d.setDate(15);`,
+        output: `import { set } from 'date-fns';\nlet d = new Date(); d = set(d, { date: 15 });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // UTC variants
+      {
+        code: `let d = new Date(); d.setUTCFullYear(2024);`,
+        output: `import { tz } from '@date-fns/tz';\nimport { set } from 'date-fns';\nlet d = new Date(); d = set(d, { year: 2024 }, { in: tz('UTC') });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+      {
+        code: `let d = new Date(); d.setUTCMonth(5);`,
+        output: `import { tz } from '@date-fns/tz';\nimport { set } from 'date-fns';\nlet d = new Date(); d = set(d, { month: 5 }, { in: tz('UTC') });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+      {
+        code: `let d = new Date(); d.setUTCDate(15);`,
+        output: `import { tz } from '@date-fns/tz';\nimport { set } from 'date-fns';\nlet d = new Date(); d = set(d, { date: 15 }, { in: tz('UTC') });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+      {
+        code: `let d = new Date(); d.setUTCHours(14);`,
+        output: `import { tz } from '@date-fns/tz';\nimport { set } from 'date-fns';\nlet d = new Date(); d = set(d, { hours: 14 }, { in: tz('UTC') });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+      {
+        code: `let d = new Date(); d.setUTCMinutes(30);`,
+        output: `import { tz } from '@date-fns/tz';\nimport { set } from 'date-fns';\nlet d = new Date(); d = set(d, { minutes: 30 }, { in: tz('UTC') });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+      {
+        code: `let d = new Date(); d.setUTCSeconds(45);`,
+        output: `import { tz } from '@date-fns/tz';\nimport { set } from 'date-fns';\nlet d = new Date(); d = set(d, { seconds: 45 }, { in: tz('UTC') });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+      {
+        code: `let d = new Date(); d.setUTCMilliseconds(500);`,
+        output: `import { tz } from '@date-fns/tz';\nimport { set } from 'date-fns';\nlet d = new Date(); d = set(d, { milliseconds: 500 }, { in: tz('UTC') });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Midnight zeroing → startOfDay()
+      {
+        code: `let d = new Date(); d.setHours(0, 0, 0, 0);`,
+        output: `import { startOfDay } from 'date-fns';\nlet d = new Date(); d = startOfDay(d);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+      {
+        code: `let d = new Date(); d.setUTCHours(0, 0, 0, 0);`,
+        output: `import { tz } from '@date-fns/tz';\nimport { startOfDay } from 'date-fns';\nlet d = new Date(); d = startOfDay(d, { in: tz('UTC') });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // setTime() → toDate()
+      {
+        code: `let d = new Date(); d.setTime(1609459200000);`,
+        output: `import { toDate } from 'date-fns';\nlet d = new Date(); d = toDate(1609459200000);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Merging with existing imports
+      {
+        code: `import { format } from 'date-fns';\nlet d = new Date(); d.setHours(14);`,
+        output: `import { format, set } from 'date-fns';\nlet d = new Date(); d = set(d, { hours: 14 });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+      {
+        code: `import { format } from 'date-fns';\nlet d = new Date(); d.setTime(1000);`,
+        output: `import { format, toDate } from 'date-fns';\nlet d = new Date(); d = toDate(1000);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+      {
+        code: `import { format } from 'date-fns';\nlet d = new Date(); d.setHours(0, 0, 0, 0);`,
+        output: `import { format, startOfDay } from 'date-fns';\nlet d = new Date(); d = startOfDay(d);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+    ],
+  });
+});
+
+test("no-date-mutation: arithmetic unit normalization", () => {
+  tester.run("no-date-mutation", rule, {
+    valid: [],
+    invalid: [
+      // Milliseconds → seconds (1000ms = 1s)
+      {
+        code: `let d = new Date(); d.setMilliseconds(d.getMilliseconds() + 1000);`,
+        output: `import { addSeconds } from 'date-fns';\nlet d = new Date(); d = addSeconds(d, 1);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Milliseconds → minutes (60000ms = 1min)
+      {
+        code: `let d = new Date(); d.setMilliseconds(d.getMilliseconds() + 60000);`,
+        output: `import { addMinutes } from 'date-fns';\nlet d = new Date(); d = addMinutes(d, 1);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Milliseconds → hours (3600000ms = 1hr)
+      {
+        code: `let d = new Date(); d.setMilliseconds(d.getMilliseconds() + 3600000);`,
+        output: `import { addHours } from 'date-fns';\nlet d = new Date(); d = addHours(d, 1);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Seconds → minutes (60s = 1min)
+      {
+        code: `let d = new Date(); d.setSeconds(d.getSeconds() + 60);`,
+        output: `import { addMinutes } from 'date-fns';\nlet d = new Date(); d = addMinutes(d, 1);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Seconds → hours (3600s = 1hr)
+      {
+        code: `let d = new Date(); d.setSeconds(d.getSeconds() + 3600);`,
+        output: `import { addHours } from 'date-fns';\nlet d = new Date(); d = addHours(d, 1);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Minutes → hours (60min = 1hr)
+      {
+        code: `let d = new Date(); d.setMinutes(d.getMinutes() + 60);`,
+        output: `import { addHours } from 'date-fns';\nlet d = new Date(); d = addHours(d, 1);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Hours → days (24hr = 1day)
+      {
+        code: `let d = new Date(); d.setHours(d.getHours() + 24);`,
+        output: `import { addDays } from 'date-fns';\nlet d = new Date(); d = addDays(d, 1);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Hours → days (48hr = 2days)
+      {
+        code: `let d = new Date(); d.setHours(d.getHours() + 48);`,
+        output: `import { addDays } from 'date-fns';\nlet d = new Date(); d = addDays(d, 2);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Days → weeks (7 days = 1 week)
+      {
+        code: `let d = new Date(); d.setDate(d.getDate() + 7);`,
+        output: `import { addWeeks } from 'date-fns';\nlet d = new Date(); d = addWeeks(d, 1);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Days → weeks (14 days = 2 weeks)
+      {
+        code: `let d = new Date(); d.setDate(d.getDate() + 14);`,
+        output: `import { addWeeks } from 'date-fns';\nlet d = new Date(); d = addWeeks(d, 2);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Months → quarters (3 months = 1 quarter)
+      {
+        code: `let d = new Date(); d.setMonth(d.getMonth() + 3);`,
+        output: `import { addQuarters } from 'date-fns';\nlet d = new Date(); d = addQuarters(d, 1);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Months → quarters (6 months = 2 quarters)
+      {
+        code: `let d = new Date(); d.setMonth(d.getMonth() + 6);`,
+        output: `import { addQuarters } from 'date-fns';\nlet d = new Date(); d = addQuarters(d, 2);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Months → years (12 months = 1 year)
+      {
+        code: `let d = new Date(); d.setMonth(d.getMonth() + 12);`,
+        output: `import { addYears } from 'date-fns';\nlet d = new Date(); d = addYears(d, 1);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Months → years (24 months = 2 years)
+      {
+        code: `let d = new Date(); d.setMonth(d.getMonth() + 24);`,
+        output: `import { addYears } from 'date-fns';\nlet d = new Date(); d = addYears(d, 2);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Subtraction: days → weeks
+      {
+        code: `let d = new Date(); d.setDate(d.getDate() - 7);`,
+        output: `import { subWeeks } from 'date-fns';\nlet d = new Date(); d = subWeeks(d, 1);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Subtraction: hours
+      {
+        code: `let d = new Date(); d.setHours(d.getHours() - 1);`,
+        output: `import { subHours } from 'date-fns';\nlet d = new Date(); d = subHours(d, 1);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Subtraction: months → years
+      {
+        code: `let d = new Date(); d.setMonth(d.getMonth() - 12);`,
+        output: `import { subYears } from 'date-fns';\nlet d = new Date(); d = subYears(d, 1);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // UTC variants: setUTCHours with arithmetic
+      {
+        code: `let d = new Date(); d.setUTCHours(d.getUTCHours() + 1);`,
+        output: `import { addHours } from 'date-fns';\nimport { tz } from '@date-fns/tz';\nlet d = new Date(); d = addHours(d, 1, { in: tz('UTC') });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // UTC variants: days → weeks
+      {
+        code: `let d = new Date(); d.setUTCDate(d.getUTCDate() + 7);`,
+        output: `import { addWeeks } from 'date-fns';\nimport { tz } from '@date-fns/tz';\nlet d = new Date(); d = addWeeks(d, 1, { in: tz('UTC') });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Non-exact multiples stay as base unit (e.g., 5 hours stays as addHours)
+      {
+        code: `let d = new Date(); d.setHours(d.getHours() + 5);`,
+        output: `import { addHours } from 'date-fns';\nlet d = new Date(); d = addHours(d, 5);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Non-exact multiples: 10 days (not a week multiple)
+      {
+        code: `let d = new Date(); d.setDate(d.getDate() + 10);`,
+        output: `import { addDays } from 'date-fns';\nlet d = new Date(); d = addDays(d, 10);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Multiple conversions: prefer largest unit (e.g., 7200000ms = 2hr not 120min)
+      {
+        code: `let d = new Date(); d.setMilliseconds(d.getMilliseconds() + 7200000);`,
+        output: `import { addHours } from 'date-fns';\nlet d = new Date(); d = addHours(d, 2);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+    ],
+  });
+});
+
+test("no-date-mutation: consecutive setters", () => {
+  tester.run("no-date-mutation", rule, {
+    valid: [],
+    invalid: [
+      // Basic consecutive setters - should merge into one set() call
+      {
+        code: `let d = new Date();\nd.setHours(14);\nd.setMinutes(30);`,
+        output: `import { set } from 'date-fns';\nlet d = new Date();\nd = set(d, { hours: 14, minutes: 30 });`,
+        errors: [{ messageId: "mutatingDate" }, { messageId: "mutatingDate" }],
+      },
+
+      // Three consecutive setters
+      {
+        code: `let d = new Date();\nd.setFullYear(2024);\nd.setMonth(5);\nd.setDate(15);`,
+        output: `import { set } from 'date-fns';\nlet d = new Date();\nd = set(d, { year: 2024, month: 5, date: 15 });`,
+        errors: [
+          { messageId: "mutatingDate" },
+          { messageId: "mutatingDate" },
+          { messageId: "mutatingDate" },
+        ],
+      },
+
+      // UTC consecutive setters
+      {
+        code: `let d = new Date();\nd.setUTCHours(14);\nd.setUTCMinutes(30);`,
+        output: `import { set } from 'date-fns';\nimport { tz } from '@date-fns/tz';\nlet d = new Date();\nd = set(d, { hours: 14, minutes: 30 }, { in: tz('UTC') });`,
+        errors: [{ messageId: "mutatingDate" }, { messageId: "mutatingDate" }],
+      },
+
+      // Different variables - should NOT merge (multi-pass fixes)
+      {
+        code: `let d1 = new Date();\nlet d2 = new Date();\nd1.setHours(14);\nd2.setMinutes(30);`,
+        output: [
+          `import { set } from 'date-fns';\nlet d1 = new Date();\nlet d2 = new Date();\nd1 = set(d1, { hours: 14 });\nd2.setMinutes(30);`,
+          `import { set } from 'date-fns';\nlet d1 = new Date();\nlet d2 = new Date();\nd1 = set(d1, { hours: 14 });\nd2 = set(d2, { minutes: 30 });`,
+        ],
+        errors: [{ messageId: "mutatingDate" }, { messageId: "mutatingDate" }],
+      },
+    ],
+  });
+});
+
+test("no-date-mutation: side effects with temp variables", () => {
+  tester.run("no-date-mutation", rule, {
+    valid: [],
+    invalid: [
+      // Side effect in single setter - needs temp variable
+      {
+        code: `let d = new Date(); d.setHours(getSomeValue());`,
+        output: `import { set } from 'date-fns';\nlet d = new Date(); const __dateFix1 = getSomeValue(); d = set(d, { hours: __dateFix1 });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Side effects in consecutive setters - needs multiple temps
+      {
+        code: `let d = new Date();\nd.setHours(getHours());\nd.setMinutes(getMinutes());`,
+        output: `import { set } from 'date-fns';\nlet d = new Date();\nconst __dateFix1 = getHours();\nconst __dateFix2 = getMinutes();\nd = set(d, { hours: __dateFix1, minutes: __dateFix2 });`,
+        errors: [{ messageId: "mutatingDate" }, { messageId: "mutatingDate" }],
+      },
+
+      // Math.* calls are pure - no temp needed
+      {
+        code: `let d = new Date(); d.setHours(Math.floor(14.5));`,
+        output: `import { set } from 'date-fns';\nlet d = new Date(); d = set(d, { hours: Math.floor(14.5) });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+
+      // Mixed: literal, Math.*, and side effect
+      {
+        code: `let d = new Date();\nd.setHours(14);\nd.setMinutes(Math.ceil(30.2));\nd.setSeconds(getSeconds());`,
+        output: `import { set } from 'date-fns';\nlet d = new Date();\nconst __dateFix1 = getSeconds();\nd = set(d, { hours: 14, minutes: Math.ceil(30.2), seconds: __dateFix1 });`,
+        errors: [
+          { messageId: "mutatingDate" },
+          { messageId: "mutatingDate" },
+          { messageId: "mutatingDate" },
+        ],
+      },
+
+      // Multiple side effects in non-consecutive setters (not merged)
+      // Each ESLint pass starts fresh, so temp vars restart from __dateFix1
+      {
+        code: `let d = new Date();\nd.setHours(getHours());\nconst x = 1;\nd.setMinutes(getMinutes());`,
+        output: [
+          `import { set } from 'date-fns';\nlet d = new Date();\nconst __dateFix1 = getHours(); d = set(d, { hours: __dateFix1 });\nconst x = 1;\nd.setMinutes(getMinutes());`,
+          `import { set } from 'date-fns';\nlet d = new Date();\nconst __dateFix1 = getHours(); d = set(d, { hours: __dateFix1 });\nconst x = 1;\nconst __dateFix1 = getMinutes(); d = set(d, { minutes: __dateFix1 });`,
+        ],
+        errors: [{ messageId: "mutatingDate" }, { messageId: "mutatingDate" }],
+      },
+    ],
+  });
+});
+
+test("no-date-mutation: UTC/local mismatch detection", () => {
+  tester.run("no-date-mutation", rule, {
+    valid: [],
+    invalid: [
+      // UTC setter with local getter - unclear intent
+      {
+        code: `let d = new Date(); d.setUTCHours(d.getHours() + 1);`,
+        errors: [
+          {
+            messageId: "mutatingDateMismatch",
+            data: {
+              reason: "UTC setter with local getter - intent unclear",
+            },
+            suggestions: [
+              {
+                messageId: "suggestUTCIntent",
+                output: `import { addHours, tz } from '@date-fns/tz';\nlet d = new Date(); d = addHours(d, 1, { in: tz('UTC') });`,
+              },
+              {
+                messageId: "suggestLocalIntent",
+                output: `import { addHours } from 'date-fns';\nlet d = new Date(); d = addHours(d, 1);`,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+});
+
+test("no-date-mutation: aliasing detection", () => {
+  tester.run("no-date-mutation", rule, {
+    valid: [],
+    invalid: [
+      // Alias created but not used after mutation - safe to fix
+      {
+        code: `const d = new Date(); const alias = d; d.setHours(5); return;`,
+        output: `import { set } from 'date-fns';\nconst d = new Date(); const alias = d; d = set(d, { hours: 5 }); return;`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+      // Alias used before mutation (safe to fix)
+      {
+        code: `let d = new Date(); const alias = d; console.log(alias); d.setHours(5);`,
+        output: `import { set } from 'date-fns';\nlet d = new Date(); const alias = d; console.log(alias); d = set(d, { hours: 5 });`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+      // Different variables (not aliases) - safe to fix
+      {
+        code: `let d1 = new Date(); let d2 = new Date(); d1.setHours(5); console.log(d2);`,
+        output: `import { set } from 'date-fns';\nlet d1 = new Date(); let d2 = new Date(); d1 = set(d1, { hours: 5 }); console.log(d2);`,
+        errors: [{ messageId: "mutatingDate" }],
+      },
+      // Alias read after mutation - unsafe to convert
+      {
+        code: `const d = new Date(); const alias = d; d.setHours(5); console.log(alias);`,
+        errors: [
+          {
+            messageId: "mutatingDateUnsafe",
+            data: {
+              reason:
+                'alias "alias" is read after mutation - changing to immutable would alter behavior',
+            },
+          },
+        ],
+      },
+      // Multiple aliases, one read after mutation
+      {
+        code: `let d = new Date(); const a1 = d; const a2 = d; d.setHours(5); console.log(a1);`,
+        errors: [
+          {
+            messageId: "mutatingDateUnsafe",
+            data: {
+              reason:
+                'alias "a1" is read after mutation - changing to immutable would alter behavior',
+            },
+          },
+        ],
+      },
+      // Alias passed to function after mutation
+      {
+        code: `let d = new Date(); const alias = d; d.setHours(5); fn(alias);`,
+        errors: [
+          {
+            messageId: "mutatingDateUnsafe",
+            data: {
+              reason:
+                'alias "alias" is read after mutation - changing to immutable would alter behavior',
+            },
+          },
+        ],
+      },
+      // Conditional read after mutation
+      {
+        code: `let d = new Date(); const alias = d; d.setHours(5); if (cond) { console.log(alias); }`,
+        errors: [
+          {
+            messageId: "mutatingDateUnsafe",
+            data: {
+              reason:
+                'alias "alias" is read after mutation - changing to immutable would alter behavior',
+            },
+          },
+        ],
+      },
+    ],
+  });
+});

--- a/test/rules/no-legacy-year-components.test.ts
+++ b/test/rules/no-legacy-year-components.test.ts
@@ -1,7 +1,7 @@
 // tests/no-legacy-year-components.test.ts
 import test from "node:test";
-import { tester } from "./_setup.ts";
-import rule from "../dist/rules/no-legacy-year-components/index.js";
+import { tester } from "../_setup.ts";
+import rule from "../../dist/rules/no-legacy-year-components/index.js";
 
 // Test cases for no-legacy-year-components rule
 // Tests detection of ambiguous 2-digit years (0-99) that map to 1900+year
@@ -281,7 +281,7 @@ test("no-legacy-year-components", () => {
               {
                 messageId: "suggestParseIso",
                 data: { iso: "0090-05-01T00:00:00.000Z" },
-                output: `import { format } from 'date-fns';\nimport { parseISO } from 'date-fns';\nconst d = parseISO('0090-05-01T00:00:00.000Z');`,
+                output: `import { format, parseISO } from 'date-fns'; const d = parseISO('0090-05-01T00:00:00.000Z');`,
               },
             ],
           },

--- a/test/rules/no-magic-time.test.ts
+++ b/test/rules/no-magic-time.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
-import { tester } from "./_setup.ts";
-import rule from "../dist/rules/no-magic-time/index.js";
+import { tester } from "../_setup.ts";
+import rule from "../../dist/rules/no-magic-time/index.js";
 
 // Test cases for no-magic-time rule
 // Detects and scores numeric literals that are likely date/time calculations

--- a/test/rules/prefer-date-fns-from-epoch.test.ts
+++ b/test/rules/prefer-date-fns-from-epoch.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
-import { tester } from "./_setup.ts";
-import rule from "../dist/rules/prefer-date-fns-from-epoch/index.js";
+import { tester } from "../_setup.ts";
+import rule from "../../dist/rules/prefer-date-fns-from-epoch/index.js";
 
 // Test cases for prefer-date-fns-from-epoch rule
 // Tests epoch timestamp detection and conversion to fromUnixTime/toDate
@@ -173,10 +173,10 @@ test("prefer-date-fns-from-epoch", () => {
         ],
       },
 
-      // Ensure we add a second top-level import line if one already exists (no merging yet)
+      // Merges into existing date-fns import
       {
         code: `import { format } from 'date-fns'; const d = new Date(1726700000000);`,
-        output: `import { format } from 'date-fns';\nimport { toDate } from 'date-fns';\nconst d = toDate(1726700000000);`,
+        output: `import { format, toDate } from 'date-fns'; const d = toDate(1726700000000);`,
         errors: [{ messageId: "preferToDate" }],
       },
 

--- a/test/rules/prefer-iso-literal-over-components.test.ts
+++ b/test/rules/prefer-iso-literal-over-components.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
-import { tester } from "./_setup.ts";
-import rule from "../dist/rules/prefer-iso-literal-over-components/index.js";
+import { tester } from "../_setup.ts";
+import rule from "../../dist/rules/prefer-iso-literal-over-components/index.js";
 
 // Test cases for prefer-iso-literal-over-components rule
 // Tests conversion of multi-argument Date constructors to ISO literals via parseISO

--- a/test/rules/require-isvalid-after-parse.test.ts
+++ b/test/rules/require-isvalid-after-parse.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
-import { tester } from "./_setup.ts";
-import rule from "../dist/rules/require-isvalid-after-parse/index.js";
+import { tester } from "../_setup.ts";
+import rule from "../../dist/rules/require-isvalid-after-parse/index.js";
 
 // Test cases for require-isvalid-after-parse rule
 // Tests enforcement of isValid() checks after parse/parseISO before date usage
@@ -326,8 +326,7 @@ function f(s: string) {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 function f(s: string) {
   const d = parseISO(s);
 if (!isValid(d)) {
@@ -359,8 +358,7 @@ function getTime(s: string) {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 function getTime(s: string) {
   const d = parseISO(s);
 if (!isValid(d)) {
@@ -393,8 +391,7 @@ function store(s: string) {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 function store(s: string) {
   const d = parseISO(s);
 if (!isValid(d)) {
@@ -427,8 +424,7 @@ function createObj(s: string) {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 function createObj(s: string) {
   const d = parseISO(s);
 if (!isValid(d)) {
@@ -460,8 +456,7 @@ function addToArray(s: string, arr: Date[]) {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 function addToArray(s: string, arr: Date[]) {
   const d = parseISO(s);
 if (!isValid(d)) {
@@ -493,8 +488,7 @@ function formatDate(s: string) {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO, format } from 'date-fns';
-import { isValid } from 'date-fns';
+import { format, isValid, parseISO } from 'date-fns';
 function formatDate(s: string) {
   const d = parseISO(s);
 if (!isValid(d)) {
@@ -526,8 +520,7 @@ function conditionalUse(s: string, useDate: boolean) {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 function conditionalUse(s: string, useDate: boolean) {
   const d = parseISO(s);
 if (!isValid(d)) {
@@ -559,8 +552,7 @@ function parseWithFormat(s: string) {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parse } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parse } from 'date-fns';
 function parseWithFormat(s: string) {
   const d = parse(s, 'yyyy-MM-dd', new Date());
 if (!isValid(d)) {
@@ -593,8 +585,7 @@ function multiUse(s: string) {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 function multiUse(s: string) {
   const d = parseISO(s);
 if (!isValid(d)) {
@@ -629,8 +620,7 @@ function processInLoop(strings: string[]) {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 function processInLoop(strings: string[]) {
   for (const s of strings) {
     const d = parseISO(s);
@@ -667,8 +657,7 @@ class Processor {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 class Processor {
   handle(s: string) {
     const d = parseISO(s);
@@ -706,8 +695,7 @@ function outer(s: string) {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 function outer(s: string) {
   const d = parseISO(s);
 if (!isValid(d)) {
@@ -784,8 +772,7 @@ function complex(s: string, flag: boolean) {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 function complex(s: string, flag: boolean) {
   const d = parseISO(s);
 if (!isValid(d)) {
@@ -818,8 +805,7 @@ function destructure(s: string) {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 function destructure(s: string) {
   const d = parseISO(s);
 if (!isValid(d)) {
@@ -889,8 +875,7 @@ function multipleViolations(s1: string, s2: string) {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 function multipleViolations(s1: string, s2: string) {
   const d1 = parseISO(s1);
 if (!isValid(d1)) {
@@ -910,8 +895,7 @@ if (!isValid(d1)) {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 function multipleViolations(s1: string, s2: string) {
   const d1 = parseISO(s1);
   const d2 = parseISO(s2);
@@ -944,8 +928,7 @@ function handleUnknown(input: unknown) {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 function handleUnknown(input: unknown) {
   const d = parseISO(input as string);
 if (!isValid(d)) {
@@ -977,8 +960,7 @@ function handleAny(input: any) {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 function handleAny(input: any) {
   const d = parseISO(input);
 if (!isValid(d)) {
@@ -1011,8 +993,7 @@ function processUnknown() {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 declare const unknownValue: unknown;
 function processUnknown() {
   const d = parseISO(unknownValue as string);
@@ -1046,8 +1027,7 @@ function processAny() {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 declare const anyValue: any;
 function processAny() {
   const d = parseISO(anyValue);
@@ -1179,8 +1159,7 @@ function useTemplateWithSubstitution(year: number) {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 function useTemplateWithSubstitution(year: number) {
   const d = parseISO(\`\${year}-01-01T00:00:00Z\`);
 if (!isValid(d)) {
@@ -1212,8 +1191,7 @@ function useStringConcatenation(month: string) {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 function useStringConcatenation(month: string) {
   const d = parseISO('2023-' + month + '-01T00:00:00Z');
 if (!isValid(d)) {
@@ -1246,8 +1224,7 @@ function mixedScenario(userInput: string) {
               {
                 messageId: "suggestGuard",
                 output: `
-import { parseISO } from 'date-fns';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 function mixedScenario(userInput: string) {
   const validConstant = parseISO('2023-01-01T00:00:00Z');
   const userDate = parseISO(userInput);

--- a/test/utils/date-call.test.ts
+++ b/test/utils/date-call.test.ts
@@ -1,0 +1,541 @@
+import test from "node:test";
+import { ESLintUtils } from "@typescript-eslint/utils";
+import { tester } from "../_setup.ts";
+import {
+  isNewDateSyntax,
+  isDateShadowed,
+  isBareGlobalDateCall,
+} from "../../dist/utils/date-call.js";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/test/${name}.md`,
+);
+
+// ============================================================================
+// Test rule for isNewDateSyntax
+// ============================================================================
+const testIsNewDateSyntaxRule = createRule({
+  name: "test-is-new-date-syntax",
+  meta: {
+    type: "problem",
+    docs: { description: "Test rule for isNewDateSyntax" },
+    messages: {
+      isDateConstructor: "This is a Date constructor",
+      notDateConstructor: "This is not a Date constructor",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      NewExpression(node) {
+        const result = isNewDateSyntax(node);
+        context.report({
+          node,
+          messageId: result ? "isDateConstructor" : "notDateConstructor",
+        });
+      },
+    };
+  },
+});
+
+// ============================================================================
+// Test rule for isDateShadowed
+// ============================================================================
+const testIsDateShadowedRule = createRule({
+  name: "test-is-date-shadowed",
+  meta: {
+    type: "problem",
+    docs: { description: "Test rule for isDateShadowed" },
+    messages: {
+      shadowed: "Date is shadowed",
+      notShadowed: "Date is not shadowed",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      NewExpression(node) {
+        const result = isDateShadowed(context, node);
+        context.report({
+          node,
+          messageId: result ? "shadowed" : "notShadowed",
+        });
+      },
+    };
+  },
+});
+
+// ============================================================================
+// Test rule for isBareGlobalDateCall
+// ============================================================================
+const testIsBareGlobalDateCallRule = createRule({
+  name: "test-is-bare-global-date-call",
+  meta: {
+    type: "problem",
+    docs: { description: "Test rule for isBareGlobalDateCall" },
+    messages: {
+      bareGlobal: "This is a bare global Date call",
+      notBareGlobal: "This is not a bare global Date call",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      CallExpression(node) {
+        const result = isBareGlobalDateCall(context, node);
+        context.report({
+          node,
+          messageId: result ? "bareGlobal" : "notBareGlobal",
+        });
+      },
+    };
+  },
+});
+
+// ============================================================================
+// TESTS: isNewDateSyntax
+// ============================================================================
+test("isNewDateSyntax: recognizes Date constructors", () => {
+  tester.run("is-new-date-syntax", testIsNewDateSyntaxRule, {
+    valid: [],
+    invalid: [
+      // Basic Date constructor
+      {
+        code: `new Date();`,
+        errors: [{ messageId: "isDateConstructor" }],
+      },
+      {
+        code: `new Date(2024, 0, 1);`,
+        errors: [{ messageId: "isDateConstructor" }],
+      },
+      {
+        code: `new Date("2024-01-01");`,
+        errors: [{ messageId: "isDateConstructor" }],
+      },
+      // globalThis.Date (cannot be shadowed)
+      {
+        code: `new globalThis.Date();`,
+        errors: [{ messageId: "isDateConstructor" }],
+      },
+      {
+        code: `new globalThis.Date(2024, 0, 1);`,
+        errors: [{ messageId: "isDateConstructor" }],
+      },
+      // Computed property: globalThis['Date']
+      {
+        code: `new globalThis['Date']();`,
+        errors: [{ messageId: "isDateConstructor" }],
+      },
+      {
+        code: `new globalThis["Date"]();`,
+        errors: [{ messageId: "isDateConstructor" }],
+      },
+    ],
+  });
+});
+
+test("isNewDateSyntax: rejects non-Date constructors", () => {
+  tester.run("is-new-date-syntax-negative", testIsNewDateSyntaxRule, {
+    valid: [],
+    invalid: [
+      // Other constructors
+      {
+        code: `new Array();`,
+        errors: [{ messageId: "notDateConstructor" }],
+      },
+      {
+        code: `new Object();`,
+        errors: [{ messageId: "notDateConstructor" }],
+      },
+      {
+        code: `new MyClass();`,
+        errors: [{ messageId: "notDateConstructor" }],
+      },
+      // Member expression but not globalThis.Date
+      {
+        code: `new myObj.Date();`,
+        errors: [{ messageId: "notDateConstructor" }],
+      },
+      {
+        code: `new window.Date();`,
+        errors: [{ messageId: "notDateConstructor" }],
+      },
+      // Computed property with non-Date value
+      {
+        code: `new globalThis['Array']();`,
+        errors: [{ messageId: "notDateConstructor" }],
+      },
+    ],
+  });
+});
+
+test("isNewDateSyntax: fast path checks", () => {
+  // Verify that simple identifier check happens first (performance)
+  tester.run("is-new-date-syntax-fast-path", testIsNewDateSyntaxRule, {
+    valid: [],
+    invalid: [
+      // Should quickly identify Date identifier
+      {
+        code: `new Date();`,
+        errors: [{ messageId: "isDateConstructor" }],
+      },
+      // Should quickly reject non-Date identifier
+      {
+        code: `new Array();`,
+        errors: [{ messageId: "notDateConstructor" }],
+      },
+      // Should handle globalThis.Date
+      {
+        code: `new globalThis.Date();`,
+        errors: [{ messageId: "isDateConstructor" }],
+      },
+    ],
+  });
+});
+
+// ============================================================================
+// TESTS: isDateShadowed
+// ============================================================================
+test("isDateShadowed: detects shadowing in various scopes", () => {
+  tester.run("is-date-shadowed-scopes", testIsDateShadowedRule, {
+    valid: [],
+    invalid: [
+      // Block scope shadowing
+      {
+        code: `{ const Date = class {}; new Date(); }`,
+        errors: [{ messageId: "shadowed" }],
+      },
+      {
+        code: `{ let Date = class {}; new Date(); }`,
+        errors: [{ messageId: "shadowed" }],
+      },
+      {
+        code: `{ var Date = class {}; new Date(); }`,
+        errors: [{ messageId: "shadowed" }],
+      },
+      // Function scope shadowing
+      {
+        code: `function test() { const Date = class {}; new Date(); }`,
+        errors: [{ messageId: "shadowed" }],
+      },
+      {
+        code: `const test = function() { const Date = class {}; new Date(); }`,
+        errors: [{ messageId: "shadowed" }],
+      },
+      {
+        code: `const test = () => { const Date = class {}; new Date(); }`,
+        errors: [{ messageId: "shadowed" }],
+      },
+      // Function parameter shadowing
+      {
+        code: `function test(Date) { new Date(); }`,
+        errors: [{ messageId: "shadowed" }],
+      },
+      {
+        code: `const test = (Date) => new Date();`,
+        errors: [{ messageId: "shadowed" }],
+      },
+      // Class scope shadowing
+      {
+        code: `class Test { method() { const Date = class {}; new Date(); } }`,
+        errors: [{ messageId: "shadowed" }],
+      },
+      // Nested scope shadowing
+      {
+        code: `function outer() { const Date = class {}; function inner() { new Date(); } }`,
+        errors: [{ messageId: "shadowed" }],
+      },
+      {
+        code: `{ const Date = class {}; { new Date(); } }`,
+        errors: [{ messageId: "shadowed" }],
+      },
+      // Import shadowing
+      {
+        code: `import { Date } from './my-date'; new Date();`,
+        errors: [{ messageId: "shadowed" }],
+      },
+      {
+        code: `import Date from './my-date'; new Date();`,
+        errors: [{ messageId: "shadowed" }],
+      },
+      {
+        code: `import * as Date from './my-date'; new Date();`,
+        errors: [{ messageId: "shadowed" }],
+      },
+      // Catch clause parameter shadowing
+      {
+        code: `try {} catch (Date) { new Date(); }`,
+        errors: [{ messageId: "shadowed" }],
+      },
+    ],
+  });
+});
+
+test("isDateShadowed: type-only imports", () => {
+  tester.run("is-date-shadowed-type-imports", testIsDateShadowedRule, {
+    valid: [],
+    invalid: [
+      // Type-only imports should still be detected by scope analysis
+      // (behavior depends on how TypeScript/parser handles type imports)
+      {
+        code: `import type { Date } from './types'; new Date();`,
+        errors: [{ messageId: "shadowed" }],
+      },
+    ],
+  });
+});
+
+test("isDateShadowed: globalThis.Date cannot be shadowed", () => {
+  tester.run("is-date-shadowed-globalthis", testIsDateShadowedRule, {
+    valid: [],
+    invalid: [
+      // globalThis.Date is never shadowed (fast-path check)
+      {
+        code: `const Date = class {}; new globalThis.Date();`,
+        errors: [{ messageId: "notShadowed" }],
+      },
+      {
+        code: `function test(Date) { new globalThis.Date(); }`,
+        errors: [{ messageId: "notShadowed" }],
+      },
+      {
+        code: `{ const Date = class {}; new globalThis.Date(); }`,
+        errors: [{ messageId: "notShadowed" }],
+      },
+      {
+        code: `{ const Date = class {}; new globalThis['Date'](); }`,
+        errors: [{ messageId: "notShadowed" }],
+      },
+    ],
+  });
+});
+
+test("isDateShadowed: not shadowed cases", () => {
+  tester.run("is-date-shadowed-not-shadowed", testIsDateShadowedRule, {
+    valid: [],
+    invalid: [
+      // Global Date without shadowing
+      {
+        code: `new Date();`,
+        errors: [{ messageId: "notShadowed" }],
+      },
+      {
+        code: `function test() { new Date(); }`,
+        errors: [{ messageId: "notShadowed" }],
+      },
+      {
+        code: `{ new Date(); }`,
+        errors: [{ messageId: "notShadowed" }],
+      },
+      // Shadowing in different scope (not affecting this usage)
+      {
+        code: `function outer() { new Date(); } function other() { const Date = class {}; }`,
+        errors: [{ messageId: "notShadowed" }],
+      },
+      // Shadowing declared after usage (hoisting matters for var)
+      {
+        code: `new Date(); var Date;`,
+        errors: [{ messageId: "shadowed" }], // var hoists
+      },
+    ],
+  });
+});
+
+test("isDateShadowed: with statement", () => {
+  // With statements can shadow variables (legacy feature)
+  tester.run("is-date-shadowed-with", testIsDateShadowedRule, {
+    valid: [],
+    invalid: [
+      // With statement shadowing (if not in strict mode)
+      {
+        code: `with ({ Date: class {} }) { new Date(); }`,
+        errors: [{ messageId: "notShadowed" }], // scope analysis doesn't track 'with' contents
+      },
+    ],
+  });
+});
+
+test("isDateShadowed: rejects non-Date constructors", () => {
+  tester.run("is-date-shadowed-non-date", testIsDateShadowedRule, {
+    valid: [],
+    invalid: [
+      // Should not report for non-Date constructors
+      {
+        code: `const Date = class {}; new Array();`,
+        errors: [{ messageId: "notShadowed" }],
+      },
+      {
+        code: `new MyClass();`,
+        errors: [{ messageId: "notShadowed" }],
+      },
+    ],
+  });
+});
+
+// ============================================================================
+// TESTS: isBareGlobalDateCall
+// ============================================================================
+test("isBareGlobalDateCall: recognizes bare Date calls", () => {
+  tester.run("is-bare-global-date-call", testIsBareGlobalDateCallRule, {
+    valid: [],
+    invalid: [
+      // Bare Date() calls
+      {
+        code: `Date();`,
+        errors: [{ messageId: "bareGlobal" }],
+      },
+      {
+        code: `const str = Date();`,
+        errors: [{ messageId: "bareGlobal" }],
+      },
+      {
+        code: `console.log(Date());`,
+        errors: [
+          { messageId: "notBareGlobal" }, // console.log() call
+          { messageId: "bareGlobal" }, // Date() call
+        ],
+      },
+    ],
+  });
+});
+
+test("isBareGlobalDateCall: detects shadowed Date calls", () => {
+  tester.run(
+    "is-bare-global-date-call-shadowed",
+    testIsBareGlobalDateCallRule,
+    {
+      valid: [],
+      invalid: [
+        // Shadowed Date() should NOT be bare global
+        {
+          code: `const Date = () => 'custom'; Date();`,
+          errors: [{ messageId: "notBareGlobal" }],
+        },
+        {
+          code: `function test(Date) { Date(); }`,
+          errors: [{ messageId: "notBareGlobal" }],
+        },
+        {
+          code: `{ const Date = () => {}; Date(); }`,
+          errors: [{ messageId: "notBareGlobal" }],
+        },
+        {
+          code: `import { Date } from './my-date'; Date();`,
+          errors: [{ messageId: "notBareGlobal" }],
+        },
+        // Catch parameter
+        {
+          code: `try {} catch (Date) { Date(); }`,
+          errors: [{ messageId: "notBareGlobal" }],
+        },
+      ],
+    },
+  );
+});
+
+test("isBareGlobalDateCall: rejects non-Date calls", () => {
+  tester.run(
+    "is-bare-global-date-call-non-date",
+    testIsBareGlobalDateCallRule,
+    {
+      valid: [],
+      invalid: [
+        // Other function calls
+        {
+          code: `Array();`,
+          errors: [{ messageId: "notBareGlobal" }],
+        },
+        {
+          code: `myFunction();`,
+          errors: [{ messageId: "notBareGlobal" }],
+        },
+        // Member expression calls (not bare)
+        {
+          code: `globalThis.Date();`,
+          errors: [{ messageId: "notBareGlobal" }],
+        },
+        {
+          code: `window.Date();`,
+          errors: [{ messageId: "notBareGlobal" }],
+        },
+        {
+          code: `obj.Date();`,
+          errors: [{ messageId: "notBareGlobal" }],
+        },
+        // Computed property
+        {
+          code: `globalThis['Date']();`,
+          errors: [{ messageId: "notBareGlobal" }],
+        },
+      ],
+    },
+  );
+});
+
+test("isBareGlobalDateCall: not shadowed in different scope", () => {
+  tester.run(
+    "is-bare-global-date-call-different-scope",
+    testIsBareGlobalDateCallRule,
+    {
+      valid: [],
+      invalid: [
+        // Date() in global scope, shadowing in other scope (declaration doesn't create CallExpression)
+        {
+          code: `Date(); function test() { const Date = () => {}; }`,
+          errors: [{ messageId: "bareGlobal" }],
+        },
+        {
+          code: `function outer() { Date(); } function other() { const Date = () => {}; Date(); }`,
+          errors: [{ messageId: "bareGlobal" }, { messageId: "notBareGlobal" }],
+        },
+      ],
+    },
+  );
+});
+
+test("isBareGlobalDateCall: fast path checks", () => {
+  // Verify identifier check happens first
+  tester.run(
+    "is-bare-global-date-call-fast-path",
+    testIsBareGlobalDateCallRule,
+    {
+      valid: [],
+      invalid: [
+        // Should quickly identify Date identifier
+        {
+          code: `Date();`,
+          errors: [{ messageId: "bareGlobal" }],
+        },
+        // Should quickly reject non-Date identifier
+        {
+          code: `Array();`,
+          errors: [{ messageId: "notBareGlobal" }],
+        },
+        // Should quickly reject member expressions
+        {
+          code: `obj.Date();`,
+          errors: [{ messageId: "notBareGlobal" }],
+        },
+      ],
+    },
+  );
+});
+
+test("isBareGlobalDateCall: complex expressions", () => {
+  tester.run("is-bare-global-date-call-complex", testIsBareGlobalDateCallRule, {
+    valid: [],
+    invalid: [
+      // Optional chaining - still detected as bare global (function only checks callee.name)
+      {
+        code: `Date?.();`,
+        errors: [{ messageId: "bareGlobal" }],
+      },
+      // Tagged template (not a call expression in the traditional sense)
+      // Note: Tagged templates are TemplateLiteral nodes, not CallExpression
+      // So they won't be checked by this function anyway
+    ],
+  });
+});

--- a/test/utils/hints.test.ts
+++ b/test/utils/hints.test.ts
@@ -1,13 +1,13 @@
 import test from "node:test";
 import { ESLintUtils } from "@typescript-eslint/utils";
-import { tester } from "./_setup.ts";
+import { tester } from "../_setup.ts";
 import {
   getIdentifierHints,
   getCommentHints,
   IDENTIFIER_TIME_KEYWORDS,
   COMMENT_TIME_KEYWORDS,
   CONSTANT_NAME_PATTERN,
-} from "../dist/rules/no-magic-time/hints.js";
+} from "../../dist/rules/no-magic-time/hints.js";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) => `https://github.com/test/${name}.md`,

--- a/test/utils/imports.test.ts
+++ b/test/utils/imports.test.ts
@@ -1,0 +1,609 @@
+import test from "node:test";
+import { ESLintUtils } from "@typescript-eslint/utils";
+import { tester } from "../_setup.ts";
+import {
+  ensureDateFnsNamedImports,
+  ensureDateFnsTzNamedImports,
+} from "../../dist/utils/imports.js";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/test/${name}.md`,
+);
+
+// ============================================================================
+// Test rule that uses ensureDateFnsNamedImports
+// ============================================================================
+const testImportsRule = createRule({
+  name: "test-imports",
+  meta: {
+    type: "problem",
+    docs: { description: "Test rule for import management" },
+    fixable: "code",
+    messages: {
+      needsImports: "Needs imports: {{names}}",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          imports: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  defaultOptions: [{ imports: [] as string[] }],
+  create(context, [options]) {
+    const importsToAdd = options.imports || [];
+
+    return {
+      Program(node) {
+        if (importsToAdd.length > 0) {
+          context.report({
+            node,
+            messageId: "needsImports",
+            data: { names: importsToAdd.join(", ") },
+            fix(fixer) {
+              const fix = ensureDateFnsNamedImports(
+                context,
+                fixer,
+                importsToAdd,
+              );
+              // eslint-disable-next-line unicorn/no-null
+              return fix ?? null;
+            },
+          });
+        }
+      },
+    };
+  },
+});
+
+// ============================================================================
+// TESTS: Basic functionality
+// ============================================================================
+test("ensureDateFnsNamedImports: adds single import to empty file", () => {
+  tester.run("imports-single-empty", testImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `const x = 1;`,
+        options: [{ imports: ["set"] }],
+        output: `import { set } from 'date-fns';\nconst x = 1;`,
+        errors: [{ messageId: "needsImports" }],
+      },
+    ],
+  });
+});
+
+test("ensureDateFnsNamedImports: adds multiple imports to empty file", () => {
+  tester.run("imports-multiple-empty", testImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `const x = 1;`,
+        options: [{ imports: ["set", "addDays", "subMonths"] }],
+        output: `import { addDays, set, subMonths } from 'date-fns';\nconst x = 1;`,
+        errors: [{ messageId: "needsImports" }],
+      },
+    ],
+  });
+});
+
+test("ensureDateFnsNamedImports: alphabetical sorting", () => {
+  tester.run("imports-alphabetical", testImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `const x = 1;`,
+        options: [{ imports: ["zoomOut", "addDays", "set", "beforeAll"] }],
+        output: `import { addDays, beforeAll, set, zoomOut } from 'date-fns';\nconst x = 1;`,
+        errors: [{ messageId: "needsImports" }],
+      },
+    ],
+  });
+});
+
+// ============================================================================
+// TESTS: Merging with existing imports
+// ============================================================================
+test("ensureDateFnsNamedImports: merges into existing import", () => {
+  tester.run("imports-merge-existing", testImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `import { set } from 'date-fns';\nconst x = 1;`,
+        options: [{ imports: ["addDays"] }],
+        output: `import { addDays, set } from 'date-fns';\nconst x = 1;`,
+        errors: [{ messageId: "needsImports" }],
+      },
+    ],
+  });
+});
+
+test("ensureDateFnsNamedImports: merges and sorts alphabetically", () => {
+  tester.run("imports-merge-sort", testImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `import { set, addMonths } from 'date-fns';\nconst x = 1;`,
+        options: [{ imports: ["addDays", "subMonths"] }],
+        output: `import { addDays, addMonths, set, subMonths } from 'date-fns';\nconst x = 1;`,
+        errors: [{ messageId: "needsImports" }],
+      },
+    ],
+  });
+});
+
+test("ensureDateFnsNamedImports: merges into first import when multiple exist", () => {
+  tester.run("imports-merge-first", testImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `import { set } from 'date-fns';\nimport { format } from 'date-fns';\nconst x = 1;`,
+        options: [{ imports: ["addDays"] }],
+        output: `import { addDays, set } from 'date-fns';\nimport { format } from 'date-fns';\nconst x = 1;`,
+        errors: [{ messageId: "needsImports" }],
+      },
+    ],
+  });
+});
+
+// ============================================================================
+// TESTS: Deduplication
+// ============================================================================
+test("ensureDateFnsNamedImports: no fix when all imports already exist", () => {
+  // Note: The rule still reports, but the fix returns undefined (no actual fix applied)
+  // This tests that the utility returns undefined when no changes are needed
+  tester.run("imports-no-fix-exists", testImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `import { set, addDays } from 'date-fns';\nconst x = 1;`,
+        options: [{ imports: ["set", "addDays"] }],
+        // No output - the fix returns undefined, so no changes are made
+        errors: [{ messageId: "needsImports" }],
+      },
+    ],
+  });
+});
+
+test("ensureDateFnsNamedImports: deduplicates input array", () => {
+  tester.run("imports-dedupe-input", testImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `const x = 1;`,
+        options: [{ imports: ["set", "addDays", "set", "addDays"] }],
+        output: `import { addDays, set } from 'date-fns';\nconst x = 1;`,
+        errors: [{ messageId: "needsImports" }],
+      },
+    ],
+  });
+});
+
+test("ensureDateFnsNamedImports: only adds missing imports", () => {
+  tester.run("imports-only-missing", testImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `import { set } from 'date-fns';\nconst x = 1;`,
+        options: [{ imports: ["set", "addDays", "subMonths"] }],
+        output: `import { addDays, set, subMonths } from 'date-fns';\nconst x = 1;`,
+        errors: [{ messageId: "needsImports" }],
+      },
+    ],
+  });
+});
+
+// ============================================================================
+// TESTS: Ignoring other import sources
+// ============================================================================
+test("ensureDateFnsNamedImports: ignores imports from other packages", () => {
+  tester.run("imports-ignore-other-packages", testImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `import { set } from 'lodash';\nimport { format } from 'other-lib';\nconst x = 1;`,
+        options: [{ imports: ["set"] }],
+        output: `import { set } from 'date-fns';\nimport { set } from 'lodash';\nimport { format } from 'other-lib';\nconst x = 1;`,
+        errors: [{ messageId: "needsImports" }],
+      },
+    ],
+  });
+});
+
+test("ensureDateFnsNamedImports: does not dedupe across packages", () => {
+  tester.run("imports-no-cross-package-dedupe", testImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `import { set } from 'lodash';\nconst x = 1;`,
+        options: [{ imports: ["set"] }],
+        output: `import { set } from 'date-fns';\nimport { set } from 'lodash';\nconst x = 1;`,
+        errors: [{ messageId: "needsImports" }],
+      },
+    ],
+  });
+});
+
+// ============================================================================
+// TESTS: Import positioning
+// ============================================================================
+test("ensureDateFnsNamedImports: adds after existing date-fns import", () => {
+  tester.run("imports-after-existing", testImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `import { set } from 'date-fns';\nimport { something } from 'other';\nconst x = 1;`,
+        options: [{ imports: ["addDays"] }],
+        output: `import { addDays, set } from 'date-fns';\nimport { something } from 'other';\nconst x = 1;`,
+        errors: [{ messageId: "needsImports" }],
+      },
+    ],
+  });
+});
+
+test("ensureDateFnsNamedImports: adds before first import when no date-fns", () => {
+  tester.run("imports-before-first", testImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `import { something } from 'other';\nconst x = 1;`,
+        options: [{ imports: ["set"] }],
+        output: `import { set } from 'date-fns';\nimport { something } from 'other';\nconst x = 1;`,
+        errors: [{ messageId: "needsImports" }],
+      },
+    ],
+  });
+});
+
+// ============================================================================
+// TESTS: Default and namespace imports
+// ============================================================================
+test("ensureDateFnsNamedImports: ignores default imports", () => {
+  tester.run("imports-ignore-default", testImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `import dateFns from 'date-fns';\nconst x = 1;`,
+        options: [{ imports: ["set"] }],
+        output: `import { set } from 'date-fns';\nimport dateFns from 'date-fns';\nconst x = 1;`,
+        errors: [{ messageId: "needsImports" }],
+      },
+    ],
+  });
+});
+
+test("ensureDateFnsNamedImports: ignores namespace imports", () => {
+  tester.run("imports-ignore-namespace", testImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `import * as dateFns from 'date-fns';\nconst x = 1;`,
+        options: [{ imports: ["set"] }],
+        output: `import { set } from 'date-fns';\nimport * as dateFns from 'date-fns';\nconst x = 1;`,
+        errors: [{ messageId: "needsImports" }],
+      },
+    ],
+  });
+});
+
+test("ensureDateFnsNamedImports: handles mixed import styles", () => {
+  tester.run("imports-mixed-styles", testImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `import dateFns from 'date-fns';\nimport { set } from 'date-fns';\nimport * as all from 'date-fns';\nconst x = 1;`,
+        options: [{ imports: ["addDays"] }],
+        output: `import dateFns from 'date-fns';\nimport { addDays, set } from 'date-fns';\nimport * as all from 'date-fns';\nconst x = 1;`,
+        errors: [{ messageId: "needsImports" }],
+      },
+    ],
+  });
+});
+
+// ============================================================================
+// TESTS: Edge cases with code on same line
+// ============================================================================
+test("ensureDateFnsNamedImports: handles code on same line as import", () => {
+  tester.run("imports-code-same-line", testImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `import { set } from 'date-fns'; const x = 1;`,
+        options: [{ imports: ["addDays"] }],
+        output: `import { addDays, set } from 'date-fns'; const x = 1;`,
+        errors: [{ messageId: "needsImports" }],
+      },
+    ],
+  });
+});
+
+// ============================================================================
+// TESTS: Empty/no-op cases
+// ============================================================================
+test("ensureDateFnsNamedImports: handles empty imports array", () => {
+  tester.run("imports-empty-array", testImportsRule, {
+    valid: [
+      {
+        code: `const x = 1;`,
+        options: [{ imports: [] }],
+      },
+    ],
+    invalid: [],
+  });
+});
+
+test("ensureDateFnsNamedImports: truly empty file edge case", () => {
+  tester.run("imports-truly-empty", testImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: ``,
+        options: [{ imports: ["set"] }],
+        output: `import { set } from 'date-fns';\n`,
+        errors: [{ messageId: "needsImports" }],
+      },
+    ],
+  });
+});
+
+// ============================================================================
+// TESTS: Complex real-world scenarios
+// ============================================================================
+test("ensureDateFnsNamedImports: complex file with multiple imports", () => {
+  tester.run("imports-complex", testImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `import React from 'react';
+import { useState } from 'react';
+import { set, format } from 'date-fns';
+import { debounce } from 'lodash';
+
+const component = () => {};`,
+        options: [{ imports: ["addDays", "subMonths", "format"] }],
+        output: `import React from 'react';
+import { useState } from 'react';
+import { addDays, format, set, subMonths } from 'date-fns';
+import { debounce } from 'lodash';
+
+const component = () => {};`,
+        errors: [{ messageId: "needsImports" }],
+      },
+    ],
+  });
+});
+
+test("ensureDateFnsNamedImports: preserves import order for non-date-fns", () => {
+  tester.run("imports-preserve-order", testImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `import z from 'z';
+import a from 'a';
+import m from 'm';
+const x = 1;`,
+        options: [{ imports: ["set"] }],
+        output: `import { set } from 'date-fns';
+import z from 'z';
+import a from 'a';
+import m from 'm';
+const x = 1;`,
+        errors: [{ messageId: "needsImports" }],
+      },
+    ],
+  });
+});
+
+// ============================================================================
+// Test rule for @date-fns/tz imports
+// ============================================================================
+const testTzImportsRule = createRule({
+  name: "test-tz-imports",
+  meta: {
+    type: "problem",
+    docs: { description: "Test rule for @date-fns/tz import management" },
+    fixable: "code",
+    messages: {
+      needsTzImports: "Needs tz imports: {{names}}",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          imports: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  defaultOptions: [{ imports: [] as string[] }],
+  create(context, [options]) {
+    const importsToAdd = options.imports || [];
+
+    return {
+      Program(node) {
+        if (importsToAdd.length > 0) {
+          context.report({
+            node,
+            messageId: "needsTzImports",
+            data: { names: importsToAdd.join(", ") },
+            fix(fixer) {
+              const fix = ensureDateFnsTzNamedImports(
+                context,
+                fixer,
+                importsToAdd,
+              );
+              // eslint-disable-next-line unicorn/no-null
+              return fix ?? null;
+            },
+          });
+        }
+      },
+    };
+  },
+});
+
+// ============================================================================
+// TESTS: @date-fns/tz import management
+// ============================================================================
+test("ensureDateFnsTzNamedImports: empty file", () => {
+  tester.run("tz-imports-empty", testTzImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `const x = 1;`,
+        options: [{ imports: ["tz"] }],
+        output: `import { tz } from '@date-fns/tz';\nconst x = 1;`,
+        errors: [{ messageId: "needsTzImports" }],
+      },
+    ],
+  });
+});
+
+test("ensureDateFnsTzNamedImports: single import - no existing", () => {
+  tester.run("tz-imports-single-new", testTzImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `const x = 1;`,
+        options: [{ imports: ["tz"] }],
+        output: `import { tz } from '@date-fns/tz';\nconst x = 1;`,
+        errors: [{ messageId: "needsTzImports" }],
+      },
+    ],
+  });
+});
+
+test("ensureDateFnsTzNamedImports: merge with existing import", () => {
+  tester.run("tz-imports-merge", testTzImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `import { tz } from '@date-fns/tz';\nconst x = 1;`,
+        options: [{ imports: ["TZDate"] }],
+        output: `import { TZDate, tz } from '@date-fns/tz';\nconst x = 1;`,
+        errors: [{ messageId: "needsTzImports" }],
+      },
+    ],
+  });
+});
+
+test("ensureDateFnsTzNamedImports: deduplicate and sort", () => {
+  tester.run("tz-imports-dedupe", testTzImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `const x = 1;`,
+        options: [{ imports: ["tz", "TZDate", "tz", "formatInTimeZone"] }],
+        output: `import { TZDate, formatInTimeZone, tz } from '@date-fns/tz';\nconst x = 1;`,
+        errors: [{ messageId: "needsTzImports" }],
+      },
+    ],
+  });
+});
+
+// NOTE: We can't easily test the "already imported - no change" case because
+// the test rule always reports an error if imports are requested, but the utility
+// correctly returns undefined when no imports are needed. The utility's behavior
+// is correct - it returns undefined when all requested imports already exist.
+// This is validated by the fact that rules using it don't create unnecessary fixes.
+// test("ensureDateFnsTzNamedImports: already imported - no change", () => {
+//   tester.run("tz-imports-existing", testTzImportsRule, {
+//     valid: [],
+//     invalid: [
+//       {
+//         code: `import { tz } from '@date-fns/tz';\nconst x = 1;`,
+//         output: `import { tz } from '@date-fns/tz';\nconst x = 1;`,
+//         options: [{ imports: ["tz"] }],
+//         errors: [{ messageId: "needsTzImports" }],
+//       },
+//     ],
+//   });
+// });
+
+test("ensureDateFnsTzNamedImports: merge multiple new imports", () => {
+  tester.run("tz-imports-merge-multiple", testTzImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `import { tz } from '@date-fns/tz';\nconst x = 1;`,
+        options: [
+          { imports: ["TZDate", "formatInTimeZone", "getTimezoneOffset"] },
+        ],
+        output: `import { TZDate, formatInTimeZone, getTimezoneOffset, tz } from '@date-fns/tz';\nconst x = 1;`,
+        errors: [{ messageId: "needsTzImports" }],
+      },
+    ],
+  });
+});
+
+test("ensureDateFnsTzNamedImports: with other imports present", () => {
+  tester.run("tz-imports-with-others", testTzImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `import { set } from 'date-fns';\nimport React from 'react';\nconst x = 1;`,
+        options: [{ imports: ["tz"] }],
+        output: `import { tz } from '@date-fns/tz';\nimport { set } from 'date-fns';\nimport React from 'react';\nconst x = 1;`,
+        errors: [{ messageId: "needsTzImports" }],
+      },
+    ],
+  });
+});
+
+test("ensureDateFnsTzNamedImports: merge with existing and other imports", () => {
+  tester.run("tz-imports-merge-complex", testTzImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `import { set } from 'date-fns';
+import { tz } from '@date-fns/tz';
+import React from 'react';
+const x = 1;`,
+        options: [{ imports: ["TZDate", "formatInTimeZone"] }],
+        output: `import { set } from 'date-fns';
+import { TZDate, formatInTimeZone, tz } from '@date-fns/tz';
+import React from 'react';
+const x = 1;`,
+        errors: [{ messageId: "needsTzImports" }],
+      },
+    ],
+  });
+});
+
+test("ensureDateFnsTzNamedImports: alphabetical sorting", () => {
+  tester.run("tz-imports-sort", testTzImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `import { tz, TZDate } from '@date-fns/tz';\nconst x = 1;`,
+        options: [{ imports: ["formatInTimeZone", "getTimezoneOffset"] }],
+        output: `import { TZDate, formatInTimeZone, getTimezoneOffset, tz } from '@date-fns/tz';\nconst x = 1;`,
+        errors: [{ messageId: "needsTzImports" }],
+      },
+    ],
+  });
+});
+
+test("ensureDateFnsTzNamedImports: separate from date-fns imports", () => {
+  tester.run("tz-imports-separate", testTzImportsRule, {
+    valid: [],
+    invalid: [
+      {
+        code: `import { set, format } from 'date-fns';\nconst x = 1;`,
+        options: [{ imports: ["tz"] }],
+        output: `import { tz } from '@date-fns/tz';\nimport { set, format } from 'date-fns';\nconst x = 1;`,
+        errors: [{ messageId: "needsTzImports" }],
+      },
+    ],
+  });
+});

--- a/test/utils/number-to-words.test.ts
+++ b/test/utils/number-to-words.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import {
   numberToWords,
   labelToConstantName,
-} from "../dist/rules/no-magic-time/number-to-words.js";
+} from "../../dist/rules/no-magic-time/number-to-words.js";
 
 describe("numberToWords", () => {
   describe("basic numbers (0-19)", () => {


### PR DESCRIPTION
This pull request introduces a new ESLint rule to prevent in-place mutation of JavaScript `Date` objects, enforces the use of immutable date-fns alternatives, and improves import fixers for better integration. It also updates documentation and test file organization to reflect these changes.

### New Rule: Date Mutation Prevention

* Added the `no-date-mutation` rule, which disallows direct mutation of `Date` instances and encourages immutable date-fns usage. The rule is documented in `docs/rules/no-date-mutation.md`, included in the recommended config (`src/configs/recommended.ts`), registered in the rule index (`src/rules/index.ts`), and referenced in the main documentation (`readme.md`). [[1]](diffhunk://#diff-c7c504f5c1f4d3334ea62c27875419398e28575a8eb583f0911c49987cd72fbaR1-R255) [[2]](diffhunk://#diff-ee7ac2e490d03c854fe269207dff9dd802bace92ee45f82870bda24315d98075R15) [[3]](diffhunk://#diff-322e2e2bfe9e4fb7c3471bb9d4f7de07372589c87c141420912ed6b00631237cR9) [[4]](diffhunk://#diff-322e2e2bfe9e4fb7c3471bb9d4f7de07372589c87c141420912ed6b00631237cR23) [[5]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R96)

### Import Fixer Improvements

* Refactored `ensureDateFnsNamedImports` to only add missing imports and merge into existing import statements, returning `undefined` when no fix is needed. Also added `ensureDateFnsTzNamedImports` for handling `@date-fns/tz` imports. [[1]](diffhunk://#diff-12dea46986159996621de13f56782295f0b3bbef10ee2450837ab59c03d54c11R5-L22) [[2]](diffhunk://#diff-12dea46986159996621de13f56782295f0b3bbef10ee2450837ab59c03d54c11L32-R179) [[3]](diffhunk://#diff-cf3c8f4ee735fecaacfbd8a698c872b267781ceb1df19e84287ad679d1a3bdcbL17-R22)
* Updated autofix outputs in tests to merge new imports into existing lines, reducing duplicate import statements. [[1]](diffhunk://#diff-631afd0da36016d6644c607dd0faddf80b482eebf3bb89544cc3e24ff9a6cc66L174-R174) [[2]](diffhunk://#diff-59ae25511e3e13a16b0d8994a0f24ac3ad30151b43ac8ffc6db808afea6b0be2L82-R87)

### Date Constructor Detection Enhancement

* Improved detection of `Date` constructor usage to handle both dot and bracket notation (`globalThis.Date` and `globalThis['Date']`). [[1]](diffhunk://#diff-12a9d86a2e97174b3212199801fb7efe9c496d90f3746a6b2ac188426c125c27L10-R10) [[2]](diffhunk://#diff-12a9d86a2e97174b3212199801fb7efe9c496d90f3746a6b2ac188426c125c27L20-R37)

### Documentation and Test Organization

* Added comprehensive documentation for the new rule, including examples, autofix details, and edge cases.
* Moved test files for rules into `test/rules/` and updated import paths for consistency. [[1]](diffhunk://#diff-631afd0da36016d6644c607dd0faddf80b482eebf3bb89544cc3e24ff9a6cc66L2-R3) [[2]](diffhunk://#diff-59ae25511e3e13a16b0d8994a0f24ac3ad30151b43ac8ffc6db808afea6b0be2L2-R3) [[3]](diffhunk://#diff-fb6d661bcf349ec8a388831697a67e669590aff20d8cf9cd56c9c685a061b3c0L2-R3)

### Dependency Updates

* Added `@date-fns/tz` as a dependency in `package.json` to support timezone-aware fixes.