### PR TITLE
No plain boundary

### DIFF
--- a/docs/rules/no-plain-boundary-math.md
+++ b/docs/rules/no-plain-boundary-math.md
@@ -1,0 +1,297 @@
+# no-plain-boundary-math
+
+Disallow manual date boundary calculations in favor of date-fns boundary helpers.
+
+🔧 This rule is automatically fixable with the `--fix` option for safe transformations.
+
+💡 This rule provides suggestions for ambiguous patterns.
+
+## Rule Details
+
+Manual date boundary calculations (start/end of day, month, week, etc.) are error-prone, hard to maintain, and obscure intent. date-fns provides clear, well-tested helper functions that handle edge cases correctly.
+
+This rule detects:
+- Plain Date setter patterns (`date.setHours(0, 0, 0, 0)`)
+- date-fns setter patterns (`set(d, { hours: 0, minutes: 0, seconds: 0, milliseconds: 0 })`)
+- Month boundary tricks (`new Date(year, month + 1, 0)`)
+- Millisecond arithmetic hacks (`new Date(+date + 86400000)`)
+- Setter chains (`setHours(setMinutes(setSeconds(d, 0), 0), 0)`)
+
+### Examples of Incorrect Code
+
+```js
+/*eslint date-fns/no-plain-boundary-math: "error"*/
+
+// ❌ Manual start of day
+const date = new Date();
+date.setHours(0, 0, 0, 0);
+
+// ❌ Manual end of day
+date.setHours(23, 59, 59, 999);
+
+// ❌ date-fns setters for boundaries
+import { set } from "date-fns";
+const start = set(d, { hours: 0, minutes: 0, seconds: 0, milliseconds: 0 });
+
+// ❌ "Next day minus 1ms" hack
+import { addDays, startOfDay, setMilliseconds } from "date-fns";
+const eod = setMilliseconds(addDays(startOfDay(d), 1), -1);
+
+// ❌ End of month trick
+const endOfMonth = new Date(year, month + 1, 0);
+
+// ❌ date-fns setter chain
+import { setHours, setMinutes, setSeconds } from "date-fns";
+const end = setSeconds(setMinutes(setHours(d, 23), 59), 59);
+
+// ❌ Millisecond arithmetic
+const tomorrow = new Date(+date + 86400000);
+
+// ❌ Start of year
+import { set } from "date-fns";
+const startYear = set(d, { month: 0, date: 1, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 });
+
+// ❌ End of year
+const endYear = set(d, { month: 11, date: 31, hours: 23, minutes: 59, seconds: 59, milliseconds: 999 });
+
+// ❌ Start of month
+const startMonth = set(d, { date: 1, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 });
+
+// ❌ Hour boundary
+date.setMinutes(0, 0, 0);
+
+// ❌ Minute boundary
+date.setSeconds(0, 0);
+
+// ❌ Second boundary
+date.setMilliseconds(0);
+
+// ❌ Week start calculation with milliseconds
+const weekStart = new Date(+date - date.getDay() * 86400000);
+```
+
+### Examples of Correct Code
+
+```js
+/*eslint date-fns/no-plain-boundary-math: "error"*/
+
+import { 
+  startOfDay, endOfDay,
+  startOfWeek, endOfWeek,
+  startOfMonth, endOfMonth,
+  startOfQuarter, endOfQuarter,
+  startOfYear, endOfYear,
+  startOfHour, endOfHour,
+  startOfMinute, endOfMinute,
+  startOfSecond,
+  addDays
+} from "date-fns";
+
+// ✅ Clear, self-documenting boundary helpers
+const start = startOfDay(date);
+const end = endOfDay(date);
+
+// ✅ Week boundaries with explicit configuration
+const weekStart = startOfWeek(date, { weekStartsOn: 1 }); // Monday
+
+// ✅ Month boundaries
+const monthStart = startOfMonth(date);
+const monthEnd = endOfMonth(date);
+
+// ✅ Year boundaries
+const yearStart = startOfYear(date);
+const yearEnd = endOfYear(date);
+
+// ✅ Hour/minute/second boundaries
+const hourStart = startOfHour(date);
+const minuteStart = startOfMinute(date);
+const secondStart = startOfSecond(date);
+
+// ✅ Date arithmetic with proper functions
+const tomorrow = addDays(date, 1);
+
+// ✅ Composed operations
+const nextWeekEnd = endOfWeek(addDays(date, 7));
+
+// ✅ Non-boundary time setting (business logic)
+date.setHours(9); // Start of business day (not a boundary)
+date.setMinutes(30); // Specific appointment time
+date.setHours(businessHourStart, 0); // Variable business hours
+```
+
+## Options
+
+This rule accepts an options object with the following properties:
+
+### `weekStartsOn`
+
+- Type: `0 | 1 | 2 | 3 | 4 | 5 | 6`
+- Default: `1` (Monday, ISO week)
+
+Specifies the first day of the week. Used when detecting/fixing week boundary patterns.
+
+- `0` = Sunday
+- `1` = Monday (default, ISO standard)
+- `2` = Tuesday
+- `3` = Wednesday
+- `4` = Thursday
+- `5` = Friday
+- `6` = Saturday
+
+Example configuration:
+
+```json
+{
+  "date-fns/no-plain-boundary-math": ["error", { "weekStartsOn": 0 }]
+}
+```
+
+### `detectHacks`
+
+- Type: `boolean`
+- Default: `true`
+
+Whether to detect and flag complex boundary hacks like millisecond arithmetic.
+
+Example configuration:
+
+```json
+{
+  "date-fns/no-plain-boundary-math": ["error", { "detectHacks": false }]
+}
+```
+
+When `false`, only direct setter patterns are detected. Millisecond math is ignored.
+
+Examples of patterns detected when `true`:
+
+```js
+// Detected as hack when detectHacks: true
+const tomorrow = new Date(+date + 86400000);
+const weekStart = new Date(+date - date.getDay() * 86400000);
+```
+
+### `suggestOnlyForAmbiguity`
+
+- Type: `boolean`
+- Default: `true`
+
+When `true`, ambiguous patterns (variables, complex expressions) only provide suggestions instead of autofixes.
+
+Example configuration:
+
+```json
+{
+  "date-fns/no-plain-boundary-math": ["error", { "suggestOnlyForAmbiguity": false }]
+}
+```
+
+When `true` (default), these patterns provide suggestions:
+
+```js
+// Provides suggestion, not autofix
+date.setHours(startHour, 0, 0, 0); // Variable value
+
+// Provides suggestion with both alternatives
+date.setHours(config.boundary ? 0 : 23, 0, 0, 0); // Conditional
+```
+
+### `endOfDayHeuristic`
+
+- Type: `"strict" | "lenient" | "aggressive"`
+- Default: `"lenient"`
+
+Controls how aggressively end-of-day patterns are detected and autofixed:
+
+#### `"strict"` Mode
+
+Only exact end-of-day patterns trigger autofixes:
+- `23:59:59.999` (all fields present)
+- "next day minus 1ms" pattern
+
+Near-EOD patterns like `23:59:59` (missing milliseconds) only trigger suggestions.
+
+```json
+{
+  "date-fns/no-plain-boundary-math": ["error", { "endOfDayHeuristic": "strict" }]
+}
+```
+
+#### `"lenient"` Mode (Default)
+
+Includes near-EOD patterns in autofixes:
+- `23:59:59.999` (autofix)
+- `23:59:59` (autofix - missing milliseconds)
+- `23:59:59.0` (autofix - explicit zero milliseconds)
+- "next day minus 1sec" pattern (autofix)
+
+Very close patterns like `23:58` still only trigger suggestions.
+
+```json
+{
+  "date-fns/no-plain-boundary-math": ["error", { "endOfDayHeuristic": "lenient" }]
+}
+```
+
+#### `"aggressive"` Mode
+
+Treats any near-EOD time as EOD intent:
+- `23:58+` (any time from 23:58 onwards)
+- `23:59` (without seconds)
+- Subtracting seconds/minutes from next day
+
+```json
+{
+  "date-fns/no-plain-boundary-math": ["error", { "endOfDayHeuristic": "aggressive" }]
+}
+```
+
+**Comparison:**
+
+| Pattern | strict | lenient | aggressive |
+|---------|--------|---------|------------|
+| `setHours(23, 59, 59, 999)` | ✅ Autofix | ✅ Autofix | ✅ Autofix |
+| `setHours(23, 59, 59, 0)` | 💡 Suggest | ✅ Autofix | ✅ Autofix |
+| `setHours(23, 59, 59)` | 💡 Suggest | ✅ Autofix | ✅ Autofix |
+| `setHours(23, 59)` | 💡 Suggest | 💡 Suggest | ✅ Autofix |
+| `setHours(23, 58)` | 💡 Suggest | 💡 Suggest | ✅ Autofix |
+
+### Complete Configuration Example
+
+```json
+{
+  "rules": {
+    "date-fns/no-plain-boundary-math": ["error", {
+      "weekStartsOn": 1,
+      "detectHacks": true,
+      "suggestOnlyForAmbiguity": true,
+      "endOfDayHeuristic": "lenient"
+    }]
+  }
+}
+```
+
+## When Not To Use It
+
+Disable this rule if:
+
+- You're not using date-fns in your project
+- You have custom Date wrappers with specific setter behavior
+- You're working with date-like objects that aren't actual Dates
+- You have performance-critical code where date-fns overhead is measured and significant
+- You're gradually migrating and want to disable for specific files
+
+## Related Rules
+
+- [`no-date-mutation`](./no-date-mutation.md) - Prevents Date mutations entirely
+- [`require-isvalid-after-parse`](./require-isvalid-after-parse.md) - Ensures parse result validation
+- [`no-magic-time`](./no-magic-time.md) - Flags magic numbers in time calculations
+
+## Version
+
+This rule was introduced in eslint-plugin-date-fns v0.3.0.
+
+## Resources
+
+- [date-fns startOf/endOf helpers documentation](https://date-fns.org/docs/Getting-Started)
+- [date-fns GitHub repository](https://github.com/date-fns/date-fns)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-date-fns",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "date-fns specific linting rules for ESLint.",
   "type": "module",
   "exports": "./dist/index.js",

--- a/readme.md
+++ b/readme.md
@@ -95,6 +95,7 @@ These rules prevent common date handling bugs and enforce safe patterns.
 | no-date-constructor-string | Forbids `new Date(string)` and `Date.parse(string)` | ISO literals to `parseISO()` | Variables get suggestions | Prefer `parseISO` or `parse` | [docs](./docs/rules/no-date-constructor-string.md) |
 | no-date-mutation | Forbid in-place Date mutation (setter methods) | Most cases | UTC/local mismatch | Enforce immutability | [docs](./docs/rules/no-date-mutation.md) |
 | no-legacy-year-components | Forbid `new Date(y, ...)` with `0 ≤ y ≤ 99` (1900+ quirk) | None | 4-digit year via `parseISO()` | Avoid century ambiguity | [docs](./docs/rules/no-legacy-year-components.md) |
+| no-plain-boundary-math | Forbid manual boundary calculations (setHours, etc.) | Most patterns | Variables/complex expressions | Use `startOfDay`, `endOfMonth`, etc. | [docs](./docs/rules/no-plain-boundary-math.md) |
 | prefer-date-fns-from-epoch | Prefer `fromUnixTime(sec)` over `new Date(number)` | Numeric literals | Variables get suggestions | Safe epoch conversion | [docs](./docs/rules/prefer-date-fns-from-epoch.md) |
 | prefer-iso-literal-over-components | Replace `new Date(y, m, d, ...)` (all numeric literals) | All-literal calls | Mixed literal/variable calls | UTC ISO format | [docs](./docs/rules/prefer-iso-literal-over-components.md) |
 | require-isvalid-after-parse | Require checking `isValid(x)` after `parse/parseISO` before use | None | Validation guard patterns | Prevent invalid date bugs | [docs](./docs/rules/require-isvalid-after-parse.md) |

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -13,6 +13,7 @@ const recommendedRules: Linter.RulesRecord = {
   "date-fns/no-legacy-year-components": "error",
   "date-fns/require-isvalid-after-parse": "error",
   "date-fns/no-date-mutation": "error",
+  "date-fns/no-plain-boundary-math": "error",
 };
 
 export default recommendedRules;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -7,6 +7,7 @@ import noLegacyYearComponents from "./no-legacy-year-components/index.js";
 import requireIsvalidAfterParse from "./require-isvalid-after-parse/index.js";
 import noMagicTime from "./no-magic-time/index.js";
 import noDateMutation from "./no-date-mutation/index.js";
+import noPlainBoundaryMath from "./no-plain-boundary-math/index.js";
 
 /**
  * Registry of all available ESLint rules provided by this plugin.
@@ -21,4 +22,5 @@ export default {
   "require-isvalid-after-parse": requireIsvalidAfterParse,
   "no-magic-time": noMagicTime,
   "no-date-mutation": noDateMutation,
+  "no-plain-boundary-math": noPlainBoundaryMath,
 };

--- a/src/rules/no-date-mutation/index.ts
+++ b/src/rules/no-date-mutation/index.ts
@@ -791,7 +791,7 @@ export default createRule<Options, MessageIds>({
       } else if (type === "field") {
         const tzOption = isUTC ? `, { in: tz('UTC') }` : "";
 
-        // Phase 4b: Use pre-assigned temp variable if argument has side effects
+        // Use pre-assigned temp variable if argument has side effects
         const temporaryVariableName = mutation.tempVarName; // Pre-assigned in Program:exit
         const effectiveArgumentText =
           temporaryVariableName || mutation.argumentText;
@@ -838,7 +838,7 @@ export default createRule<Options, MessageIds>({
       const isUTC = first.isUTC;
       const tzOption = isUTC ? `, { in: tz('UTC') }` : "";
 
-      // Phase 4b: Use pre-assigned temp variables for side effects
+      // Use pre-assigned temp variables for side effects
       const temporaryVariableMap = new Map<string, string>(); // maps argumentText to temp var name
       const mutationsWithTemps = group.map((m) => {
         if (m.tempVarName && m.argumentText) {

--- a/src/rules/no-plain-boundary-math/index.ts
+++ b/src/rules/no-plain-boundary-math/index.ts
@@ -58,12 +58,6 @@ const DATE_SETTERS = new Set([
 // Time constants in milliseconds
 const MS_PER_DAY = 86_400_000;
 
-export interface RuleOptions {
-  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
-  detectHacks?: boolean;
-  suggestOnlyForAmbiguity?: boolean;
-  endOfDayHeuristic?: EndOfDayHeuristic;
-}
 
 export default createRule<Options, MessageIds>({
   name: "no-plain-boundary-math",

--- a/src/rules/no-plain-boundary-math/index.ts
+++ b/src/rules/no-plain-boundary-math/index.ts
@@ -1,0 +1,1325 @@
+import { ESLintUtils, type TSESTree } from "@typescript-eslint/utils";
+import { createImportAndReplaceFix } from "../../utils/fixers.js";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/ChristianMurphy/eslint-plugin-date-fns/blob/main/docs/rules/${name}.md`,
+);
+
+type EndOfDayHeuristic = "strict" | "lenient" | "aggressive";
+
+export interface RuleOptions {
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  detectHacks?: boolean;
+  suggestOnlyForAmbiguity?: boolean;
+  endOfDayHeuristic?: EndOfDayHeuristic;
+}
+
+type Options = [RuleOptions?];
+
+type MessageIds =
+  | "useStartOfDay"
+  | "useEndOfDay"
+  | "useStartOfWeek"
+  | "useEndOfWeek"
+  | "useStartOfMonth"
+  | "useEndOfMonth"
+  | "useStartOfQuarter"
+  | "useEndOfQuarter"
+  | "useStartOfYear"
+  | "useEndOfYear"
+  | "useStartOfHour"
+  | "useStartOfMinute"
+  | "useStartOfSecond"
+  | "useAddDays"
+  | "possibleBoundary"
+  | "nearEndOfDay"
+  | "mixedUtcLocal"
+  | "complexBoundaryExpression"
+  | "dstWarning"
+  | "suggestStartOfDay"
+  | "suggestEndOfDay"
+  | "suggestStartOfWeek"
+  | "suggestEndOfMonth"
+  | "suggestLocalBoundary"
+  | "suggestKeepAsIs"
+  | "suggestStartOrEnd";
+
+const DATE_SETTERS = new Set([
+  "setFullYear",
+  "setMonth",
+  "setDate",
+  "setHours",
+  "setMinutes",
+  "setSeconds",
+  "setMilliseconds",
+]);
+
+// Time constants in milliseconds
+const MS_PER_DAY = 86_400_000;
+
+export interface RuleOptions {
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  detectHacks?: boolean;
+  suggestOnlyForAmbiguity?: boolean;
+  endOfDayHeuristic?: EndOfDayHeuristic;
+}
+
+export default createRule<Options, MessageIds>({
+  name: "no-plain-boundary-math",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow manual date boundary calculations in favor of date-fns boundary helpers",
+    },
+    fixable: "code",
+    hasSuggestions: true,
+    messages: {
+      useStartOfDay:
+        "Use startOfDay() instead of manually setting to start of day",
+      useEndOfDay: "Use endOfDay() instead of manually setting to end of day",
+      useStartOfWeek:
+        "Use startOfWeek() instead of manual week start calculation",
+      useEndOfWeek: "Use endOfWeek() instead of manual week end calculation",
+      useStartOfMonth:
+        "Use startOfMonth() instead of manually setting to start of month",
+      useEndOfMonth: "Use endOfMonth() instead of day 0 trick for end of month",
+      useStartOfQuarter:
+        "Use startOfQuarter() instead of manual quarter start calculation",
+      useEndOfQuarter:
+        "Use endOfQuarter() instead of manual quarter end calculation",
+      useStartOfYear:
+        "Use startOfYear() instead of manually setting to start of year",
+      useEndOfYear:
+        "Use endOfYear() instead of manually setting to end of year",
+      useStartOfHour:
+        "Use startOfHour() instead of manually zeroing minutes/seconds",
+      useStartOfMinute:
+        "Use startOfMinute() instead of manually zeroing seconds",
+      useStartOfSecond:
+        "Use startOfSecond() instead of manually zeroing milliseconds",
+      useAddDays: "Use addDays() instead of millisecond arithmetic",
+      possibleBoundary:
+        "This may be a boundary calculation. Consider using date-fns helpers",
+      nearEndOfDay:
+        "This appears to be near end-of-day. Consider using endOfDay()",
+      mixedUtcLocal:
+        "Mixed UTC and local setters detected. Consider consistent timezone handling",
+      complexBoundaryExpression:
+        "Complex boundary expression detected. Consider date-fns helpers",
+      dstWarning:
+        "Boundary calculation near DST transition. date-fns helpers handle this correctly",
+      suggestStartOfDay: "Replace with startOfDay()",
+      suggestEndOfDay: "Replace with endOfDay()",
+      suggestStartOfWeek: "Replace with startOfWeek()",
+      suggestEndOfMonth: "Replace with endOfMonth()",
+      suggestLocalBoundary: "Use local-time boundary helper",
+      suggestKeepAsIs: "Keep existing code (not a boundary)",
+      suggestStartOrEnd: "Replace with conditional using startOfDay/endOfDay",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          weekStartsOn: {
+            type: "number",
+            enum: [0, 1, 2, 3, 4, 5, 6],
+            description: "The day of the week to start on (0=Sunday, 1=Monday)",
+          },
+          detectHacks: {
+            type: "boolean",
+            description: "Whether to detect millisecond arithmetic hacks",
+          },
+          suggestOnlyForAmbiguity: {
+            type: "boolean",
+            description: "Only suggest fixes for ambiguous patterns",
+          },
+          endOfDayHeuristic: {
+            type: "string",
+            enum: ["strict", "lenient", "aggressive"],
+            description: "Strictness level for detecting end-of-day patterns",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    defaultOptions: [
+      {
+        weekStartsOn: 1,
+        detectHacks: true,
+        suggestOnlyForAmbiguity: true,
+        endOfDayHeuristic: "lenient",
+      },
+    ],
+  },
+  defaultOptions: [
+    {
+      weekStartsOn: 1,
+      detectHacks: true,
+      suggestOnlyForAmbiguity: true,
+      endOfDayHeuristic: "lenient",
+    },
+  ],
+  create(context, [options]) {
+    const sourceCode = context.sourceCode;
+    const services = ESLintUtils.getParserServices(context);
+    const checker = services?.program?.getTypeChecker();
+
+    // Track date-fns imports
+    const dateFnsImports = new Map<string, string>(); // localName -> importedName
+
+    return {
+      // Track date-fns imports
+      ImportDeclaration(node: TSESTree.ImportDeclaration) {
+        if (node.source.value === "date-fns") {
+          for (const specifier of node.specifiers) {
+            if (specifier.type === "ImportSpecifier") {
+              const imported = specifier.imported;
+              const importedName =
+                imported.type === "Identifier" ? imported.name : imported.value;
+              const localName = specifier.local.name;
+              dateFnsImports.set(localName, importedName);
+            }
+          }
+        }
+      },
+
+      "CallExpression[callee.type='MemberExpression']"(
+        node: TSESTree.CallExpression,
+      ) {
+        if (node.callee.type !== "MemberExpression") return;
+        const callee = node.callee;
+        if (callee.property.type !== "Identifier") return;
+
+        const methodName = callee.property.name;
+        if (!DATE_SETTERS.has(methodName)) return;
+
+        const objectNode = callee.object;
+
+        // Skip if the object type is any or unknown
+        if (shouldSkipType(objectNode, checker, services)) return;
+
+        // Check if setHours is used for its return value (timestamp)
+        const parent = node.parent;
+        const needsTimestamp =
+          parent &&
+          (parent.type === "VariableDeclarator" ||
+            parent.type === "AssignmentExpression" ||
+            parent.type === "ReturnStatement" ||
+            parent.type === "ArrowFunctionExpression" ||
+            (parent.type === "CallExpression" &&
+              parent.arguments.includes(node)));
+
+        // Check for start of day pattern: setHours(0, 0, 0, 0)
+        if (methodName === "setHours" && node.arguments.length === 4) {
+          const arguments_ = node.arguments;
+          if (
+            arguments_.every(
+              (argument) => argument.type === "Literal" && argument.value === 0,
+            )
+          ) {
+            context.report({
+              node,
+              messageId: "useStartOfDay",
+              fix(fixer) {
+                const objectText = sourceCode.getText(objectNode);
+                const replacement = needsTimestamp
+                  ? `+startOfDay(${objectText})`
+                  : `startOfDay(${objectText})`;
+
+                return createImportAndReplaceFix(
+                  context,
+                  fixer,
+                  ["startOfDay"],
+                  node,
+                  replacement,
+                );
+              },
+            });
+            return;
+          }
+        }
+
+        // Check for end of day patterns
+        if (methodName === "setHours") {
+          const heuristic = options?.endOfDayHeuristic ?? "lenient";
+          const arguments_ = node.arguments;
+
+          // Helper to check if argument is a literal with specific value
+          const isLiteralValue = (
+            argument: TSESTree.Node | undefined,
+            value: number,
+          ) => argument?.type === "Literal" && argument.value === value;
+
+          const argumentCount = arguments_.length;
+          let shouldAutofix = false;
+          let shouldSuggest = false;
+
+          switch (argumentCount) {
+            case 4: {
+              const [hours, minutes, seconds, ms] = arguments_;
+              const is23_59_59_999 =
+                isLiteralValue(hours, 23) &&
+                isLiteralValue(minutes, 59) &&
+                isLiteralValue(seconds, 59) &&
+                isLiteralValue(ms, 999);
+
+              const is23_59_59_0 =
+                isLiteralValue(hours, 23) &&
+                isLiteralValue(minutes, 59) &&
+                isLiteralValue(seconds, 59) &&
+                isLiteralValue(ms, 0);
+
+              const is23_58Plus =
+                isLiteralValue(hours, 23) &&
+                minutes?.type === "Literal" &&
+                typeof minutes.value === "number" &&
+                minutes.value >= 58;
+
+              // Always autofix canonical 23:59:59.999
+              if (is23_59_59_999) {
+                shouldAutofix = true;
+              }
+              // Lenient/Aggressive: autofix 23:59:59.0
+              else if (heuristic !== "strict" && is23_59_59_0) {
+                shouldAutofix = true;
+              }
+              // Aggressive: autofix 23:58+
+              else if (heuristic === "aggressive" && is23_58Plus) {
+                shouldAutofix = true;
+              }
+              // Strict/Lenient: suggest for 23:58+
+              else if (heuristic !== "aggressive" && is23_58Plus) {
+                shouldSuggest = true;
+              }
+
+              break;
+            }
+            case 3: {
+              const [hours, minutes, seconds] = arguments_;
+              const is23_59_59 =
+                isLiteralValue(hours, 23) &&
+                isLiteralValue(minutes, 59) &&
+                isLiteralValue(seconds, 59);
+
+              // Lenient/Aggressive: autofix 23:59:59
+              if (heuristic !== "strict" && is23_59_59) {
+                shouldAutofix = true;
+              }
+              // Strict: suggest for 23:59:59
+              else if (heuristic === "strict" && is23_59_59) {
+                shouldSuggest = true;
+              }
+
+              break;
+            }
+            case 2: {
+              const [hours, minutes] = arguments_;
+              const is23_58Plus =
+                isLiteralValue(hours, 23) &&
+                minutes?.type === "Literal" &&
+                typeof minutes.value === "number" &&
+                minutes.value >= 58;
+
+              // Aggressive: autofix 23:58 or 23:59
+              if (heuristic === "aggressive" && is23_58Plus) {
+                shouldAutofix = true;
+              }
+              // Strict/Lenient: suggest for 23:58+
+              else if (heuristic !== "aggressive" && is23_58Plus) {
+                shouldSuggest = true;
+              }
+
+              break;
+            }
+            // No default
+          }
+
+          if (shouldAutofix) {
+            context.report({
+              node,
+              messageId: "useEndOfDay",
+              fix(fixer) {
+                const objectText = sourceCode.getText(objectNode);
+                const replacement = needsTimestamp
+                  ? `+endOfDay(${objectText})`
+                  : `endOfDay(${objectText})`;
+
+                return createImportAndReplaceFix(
+                  context,
+                  fixer,
+                  ["endOfDay"],
+                  node,
+                  replacement,
+                );
+              },
+            });
+            return;
+          } else if (shouldSuggest) {
+            context.report({
+              node,
+              messageId: "nearEndOfDay",
+              suggest: [
+                {
+                  messageId: "suggestEndOfDay",
+                  fix(fixer) {
+                    const objectText = sourceCode.getText(objectNode);
+                    const replacement = needsTimestamp
+                      ? `+endOfDay(${objectText})`
+                      : `endOfDay(${objectText})`;
+
+                    return createImportAndReplaceFix(
+                      context,
+                      fixer,
+                      ["endOfDay"],
+                      node,
+                      replacement,
+                    );
+                  },
+                },
+              ],
+            });
+            return;
+          }
+        }
+
+        // Check for ambiguous patterns with non-literal values
+        if (methodName === "setHours" && node.arguments.length === 4) {
+          const [hours, minutes, seconds, ms] = node.arguments;
+
+          // Check if hours is non-literal but other args are literals (boundary indicators)
+          const hasNonLiteralHours = hours && hours.type !== "Literal";
+          const otherArgumentsAreBoundaryLike =
+            minutes?.type === "Literal" &&
+            seconds?.type === "Literal" &&
+            ms?.type === "Literal" &&
+            minutes.value === 0 &&
+            seconds.value === 0 &&
+            ms.value === 0;
+
+          // Skip complex expressions that we can't confidently analyze
+          // (LogicalExpression like || or &&, ChainExpression with optional chaining)
+          const isExcludedExpression =
+            hours &&
+            (hours.type === "LogicalExpression" ||
+              hours.type === "ChainExpression");
+
+          if (
+            hasNonLiteralHours &&
+            otherArgumentsAreBoundaryLike &&
+            hours &&
+            !isExcludedExpression
+          ) {
+            // Check if hours is a simple conditional (ternary) with boundary values
+            const isComplexExpression =
+              hours.type === "ConditionalExpression" &&
+              ((hours.consequent.type === "Literal" &&
+                (hours.consequent.value === 0 ||
+                  hours.consequent.value === 23)) ||
+                (hours.alternate.type === "Literal" &&
+                  (hours.alternate.value === 0 ||
+                    hours.alternate.value === 23)));
+
+            const messageId = isComplexExpression
+              ? "complexBoundaryExpression"
+              : "possibleBoundary";
+
+            const suggestionMessageId = isComplexExpression
+              ? "suggestStartOrEnd"
+              : "suggestStartOfDay";
+
+            context.report({
+              node,
+              messageId,
+              suggest: [
+                {
+                  messageId: suggestionMessageId,
+                  fix(fixer) {
+                    const objectText = sourceCode.getText(objectNode);
+                    let replacement: string;
+
+                    if (
+                      isComplexExpression &&
+                      hours.type === "ConditionalExpression"
+                    ) {
+                      // For complex expressions, suggest conditional startOfDay/endOfDay
+                      const testText = sourceCode.getText(hours.test);
+                      const needsTimestampPrefix = needsTimestamp ? "+" : "";
+                      replacement = `${testText} ? ${needsTimestampPrefix}startOfDay(${objectText}) : ${needsTimestampPrefix}endOfDay(${objectText})`;
+
+                      return createImportAndReplaceFix(
+                        context,
+                        fixer,
+                        ["startOfDay", "endOfDay"],
+                        node,
+                        replacement,
+                      );
+                    } else {
+                      // For simple variables, suggest startOfDay
+                      replacement = needsTimestamp
+                        ? `+startOfDay(${objectText})`
+                        : `startOfDay(${objectText})`;
+
+                      return createImportAndReplaceFix(
+                        context,
+                        fixer,
+                        ["startOfDay"],
+                        node,
+                        replacement,
+                      );
+                    }
+                  },
+                },
+              ],
+            });
+            return;
+          }
+        }
+        // Check for start of hour: setMinutes(0, 0, 0)
+        if (methodName === "setMinutes" && node.arguments.length === 3) {
+          const arguments_ = node.arguments;
+          if (
+            arguments_.every(
+              (argument) => argument.type === "Literal" && argument.value === 0,
+            )
+          ) {
+            context.report({
+              node,
+              messageId: "useStartOfHour",
+              fix(fixer) {
+                const objectText = sourceCode.getText(objectNode);
+                const replacement = needsTimestamp
+                  ? `+startOfHour(${objectText})`
+                  : `startOfHour(${objectText})`;
+
+                return createImportAndReplaceFix(
+                  context,
+                  fixer,
+                  ["startOfHour"],
+                  node,
+                  replacement,
+                );
+              },
+            });
+            return;
+          }
+        }
+
+        // Check for start of minute: setSeconds(0, 0)
+        if (methodName === "setSeconds" && node.arguments.length === 2) {
+          const arguments_ = node.arguments;
+          if (
+            arguments_.every(
+              (argument) => argument.type === "Literal" && argument.value === 0,
+            )
+          ) {
+            context.report({
+              node,
+              messageId: "useStartOfMinute",
+              fix(fixer) {
+                const objectText = sourceCode.getText(objectNode);
+                const replacement = needsTimestamp
+                  ? `+startOfMinute(${objectText})`
+                  : `startOfMinute(${objectText})`;
+
+                return createImportAndReplaceFix(
+                  context,
+                  fixer,
+                  ["startOfMinute"],
+                  node,
+                  replacement,
+                );
+              },
+            });
+            return;
+          }
+        }
+
+        // Check for start of second: setMilliseconds(0)
+        if (methodName === "setMilliseconds" && node.arguments.length === 1) {
+          const argument = node.arguments[0];
+          if (argument?.type === "Literal" && argument.value === 0) {
+            context.report({
+              node,
+              messageId: "useStartOfSecond",
+              fix(fixer) {
+                const objectText = sourceCode.getText(objectNode);
+                const replacement = needsTimestamp
+                  ? `+startOfSecond(${objectText})`
+                  : `startOfSecond(${objectText})`;
+
+                return createImportAndReplaceFix(
+                  context,
+                  fixer,
+                  ["startOfSecond"],
+                  node,
+                  replacement,
+                );
+              },
+            });
+            return;
+          }
+        }
+      },
+
+      // Detect date-fns set() and setter chains
+      CallExpression(node: TSESTree.CallExpression) {
+        // Skip MemberExpression calls (handled above)
+        if (node.callee.type === "MemberExpression") return;
+
+        // Check for date-fns set() with boundary object
+        if (
+          isDateFnsFunction(node, "set", dateFnsImports) &&
+          node.arguments.length === 2
+        ) {
+          const objectArgument = node.arguments[1];
+          if (objectArgument?.type === "ObjectExpression") {
+            const properties = objectArgument.properties;
+            const propertyMap = new Map<string, number>();
+
+            // Build map of property names to literal values
+            for (const property of properties) {
+              if (
+                property.type === "Property" &&
+                property.key.type === "Identifier" &&
+                property.value.type === "Literal" &&
+                typeof property.value.value === "number"
+              ) {
+                propertyMap.set(property.key.name, property.value.value);
+              }
+            }
+
+            // Check for month boundary patterns first
+            const isStartOfMonth =
+              propertyMap.get("date") === 1 &&
+              propertyMap.get("hours") === 0 &&
+              propertyMap.get("minutes") === 0 &&
+              propertyMap.get("seconds") === 0 &&
+              propertyMap.get("milliseconds") === 0 &&
+              !propertyMap.has("year") &&
+              !propertyMap.has("month");
+
+            if (isStartOfMonth) {
+              const dateArgument = node.arguments[0];
+              if (!dateArgument) return;
+
+              context.report({
+                node,
+                messageId: "useStartOfMonth",
+                fix(fixer) {
+                  const dateArgumentText = sourceCode.getText(dateArgument);
+                  return createImportAndReplaceFix(
+                    context,
+                    fixer,
+                    ["startOfMonth"],
+                    node,
+                    `startOfMonth(${dateArgumentText})`,
+                  );
+                },
+              });
+              return;
+            }
+
+            // Check for year boundary patterns
+            const isStartOfYear =
+              propertyMap.get("month") === 0 &&
+              propertyMap.get("date") === 1 &&
+              propertyMap.get("hours") === 0 &&
+              propertyMap.get("minutes") === 0 &&
+              propertyMap.get("seconds") === 0 &&
+              propertyMap.get("milliseconds") === 0 &&
+              !propertyMap.has("year");
+
+            if (isStartOfYear) {
+              const dateArgument = node.arguments[0];
+              if (!dateArgument) return;
+
+              context.report({
+                node,
+                messageId: "useStartOfYear",
+                fix(fixer) {
+                  const dateArgumentText = sourceCode.getText(dateArgument);
+                  return createImportAndReplaceFix(
+                    context,
+                    fixer,
+                    ["startOfYear"],
+                    node,
+                    `startOfYear(${dateArgumentText})`,
+                  );
+                },
+              });
+              return;
+            }
+
+            const isEndOfYear =
+              propertyMap.get("month") === 11 &&
+              propertyMap.get("date") === 31 &&
+              propertyMap.get("hours") === 23 &&
+              propertyMap.get("minutes") === 59 &&
+              propertyMap.get("seconds") === 59 &&
+              propertyMap.get("milliseconds") === 999 &&
+              !propertyMap.has("year");
+
+            if (isEndOfYear) {
+              const dateArgument = node.arguments[0];
+              if (!dateArgument) return;
+
+              context.report({
+                node,
+                messageId: "useEndOfYear",
+                fix(fixer) {
+                  const dateArgumentText = sourceCode.getText(dateArgument);
+                  return createImportAndReplaceFix(
+                    context,
+                    fixer,
+                    ["endOfYear"],
+                    node,
+                    `endOfYear(${dateArgumentText})`,
+                  );
+                },
+              });
+              return;
+            }
+
+            // Check if it's ONLY time properties (no year/month/date)
+            const hasDateProperties = ["year", "month", "date"].some((key) =>
+              propertyMap.has(key),
+            );
+
+            if (!hasDateProperties) {
+              // Check for start of day pattern
+              const isStartOfDay =
+                propertyMap.get("hours") === 0 &&
+                propertyMap.get("minutes") === 0 &&
+                propertyMap.get("seconds") === 0 &&
+                propertyMap.get("milliseconds") === 0;
+
+              if (isStartOfDay) {
+                const dateArgument = node.arguments[0];
+                if (!dateArgument) return;
+
+                context.report({
+                  node,
+                  messageId: "useStartOfDay",
+                  fix(fixer) {
+                    const dateArgumentText = sourceCode.getText(dateArgument);
+                    return createImportAndReplaceFix(
+                      context,
+                      fixer,
+                      ["startOfDay"],
+                      node,
+                      `startOfDay(${dateArgumentText})`,
+                    );
+                  },
+                });
+                return;
+              }
+
+              // Check for end of day patterns
+              const heuristic = options?.endOfDayHeuristic ?? "lenient";
+              const hours = propertyMap.get("hours");
+              const minutes = propertyMap.get("minutes");
+              const seconds = propertyMap.get("seconds");
+              const ms = propertyMap.get("milliseconds");
+
+              const isEndOfDay = isEndOfDayPattern(
+                hours,
+                minutes,
+                seconds,
+                ms,
+                heuristic,
+              );
+              const shouldSuggest =
+                !isEndOfDay &&
+                heuristic !== "aggressive" &&
+                isNearEndOfDay(hours, minutes);
+
+              if (isEndOfDay) {
+                const dateArgument = node.arguments[0];
+                if (!dateArgument) return;
+
+                context.report({
+                  node,
+                  messageId: "useEndOfDay",
+                  fix(fixer) {
+                    const dateArgumentText = sourceCode.getText(dateArgument);
+                    return createImportAndReplaceFix(
+                      context,
+                      fixer,
+                      ["endOfDay"],
+                      node,
+                      `endOfDay(${dateArgumentText})`,
+                    );
+                  },
+                });
+                return;
+              } else if (shouldSuggest) {
+                const dateArgument = node.arguments[0];
+                if (!dateArgument) return;
+
+                context.report({
+                  node,
+                  messageId: "nearEndOfDay",
+                  suggest: [
+                    {
+                      messageId: "suggestEndOfDay",
+                      fix(fixer) {
+                        const dateArgumentText =
+                          sourceCode.getText(dateArgument);
+                        return createImportAndReplaceFix(
+                          context,
+                          fixer,
+                          ["endOfDay"],
+                          node,
+                          `endOfDay(${dateArgumentText})`,
+                        );
+                      },
+                    },
+                  ],
+                });
+                return;
+              }
+            }
+          }
+        }
+
+        // Check for date-fns setter chains: setHours(setMinutes(setSeconds(...)))
+        // Detect patterns like:
+        // - setHours(setMinutes(setSeconds(setMilliseconds(d, 0), 0), 0), 0) → startOfDay
+        // - setHours(setMinutes(d, 0), 0) → startOfHour
+        // - setSeconds(setMinutes(setHours(d, 23), 59), 59) → endOfDay
+        if (node.callee.type === "Identifier") {
+          const setterName = node.callee.name;
+          const setterFunctions = new Set([
+            "setHours",
+            "setMinutes",
+            "setSeconds",
+            "setMilliseconds",
+          ]);
+
+          // Check if this is a date-fns setter function
+          const importedName = dateFnsImports.get(setterName);
+
+          if (importedName && setterFunctions.has(importedName)) {
+            // Check if this node is nested inside another setter chain
+            // If so, skip it - we'll handle it at the outermost level
+            const parent = node.parent;
+            if (
+              parent?.type === "CallExpression" &&
+              parent.callee.type === "Identifier"
+            ) {
+              const parentImportedName = dateFnsImports.get(parent.callee.name);
+              if (
+                parentImportedName &&
+                setterFunctions.has(parentImportedName)
+              ) {
+                // This is nested inside another date-fns setter, skip it
+                return;
+              }
+            }
+
+            // Analyze the chain to extract all values
+            const chainInfo = analyzeSetterChain(node);
+
+            if (chainInfo) {
+              const { hours, minutes, seconds, milliseconds } = chainInfo;
+
+              // Check for start of day: ALL FOUR explicitly set to 0
+              if (isStartOfDayPattern(hours, minutes, seconds, milliseconds)) {
+                context.report({
+                  node,
+                  messageId: "useStartOfDay",
+                  fix(fixer) {
+                    const dateArgumentText = sourceCode.getText(
+                      chainInfo.dateArgument,
+                    );
+                    return createImportAndReplaceFix(
+                      context,
+                      fixer,
+                      ["startOfDay"],
+                      node,
+                      `startOfDay(${dateArgumentText})`,
+                    );
+                  },
+                });
+                return;
+              }
+
+              // Check for start of hour: setHours(setMinutes(d, 0), 0)
+              // ONLY hours and minutes set (to 0), seconds/ms not touched
+              if (
+                hours === 0 &&
+                minutes === 0 &&
+                seconds === undefined &&
+                milliseconds === undefined
+              ) {
+                context.report({
+                  node,
+                  messageId: "useStartOfHour",
+                  fix(fixer) {
+                    const dateArgumentText = sourceCode.getText(
+                      chainInfo.dateArgument,
+                    );
+                    return createImportAndReplaceFix(
+                      context,
+                      fixer,
+                      ["startOfHour"],
+                      node,
+                      `startOfHour(${dateArgumentText})`,
+                    );
+                  },
+                });
+                return;
+              }
+
+              // Check for end of day patterns in setter chains
+              const chainHeuristic = options?.endOfDayHeuristic ?? "lenient";
+
+              // Check if we have an EOD pattern
+              const isChainEndOfDay = isEndOfDayPattern(
+                hours,
+                minutes,
+                seconds,
+                milliseconds,
+                chainHeuristic,
+              );
+
+              if (isChainEndOfDay) {
+                context.report({
+                  node,
+                  messageId: "useEndOfDay",
+                  fix(fixer) {
+                    const dateArgumentText = sourceCode.getText(
+                      chainInfo.dateArgument,
+                    );
+                    return createImportAndReplaceFix(
+                      context,
+                      fixer,
+                      ["endOfDay"],
+                      node,
+                      `endOfDay(${dateArgumentText})`,
+                    );
+                  },
+                });
+                return;
+              }
+
+              // Check for start of minute: setMinutes(setSeconds(setMilliseconds(d, 0), 0), 0)
+              // hours is undefined, ONLY minutes, seconds, ms are set (to 0)
+              if (
+                hours === undefined &&
+                minutes === 0 &&
+                seconds === 0 &&
+                milliseconds === 0
+              ) {
+                context.report({
+                  node,
+                  messageId: "useStartOfHour",
+                  fix(fixer) {
+                    const dateArgumentText = sourceCode.getText(
+                      chainInfo.dateArgument,
+                    );
+                    return createImportAndReplaceFix(
+                      context,
+                      fixer,
+                      ["startOfHour"],
+                      node,
+                      `startOfHour(${dateArgumentText})`,
+                    );
+                  },
+                });
+                return;
+              }
+
+              // Check for end of day patterns
+              const heuristic = options?.endOfDayHeuristic ?? "lenient";
+              const isEndOfDay = isEndOfDayPattern(
+                hours,
+                minutes,
+                seconds,
+                milliseconds,
+                heuristic,
+              );
+
+              if (isEndOfDay) {
+                context.report({
+                  node,
+                  messageId: "useEndOfDay",
+                  fix(fixer) {
+                    const dateArgumentText = sourceCode.getText(
+                      chainInfo.dateArgument,
+                    );
+                    return createImportAndReplaceFix(
+                      context,
+                      fixer,
+                      ["endOfDay"],
+                      node,
+                      `endOfDay(${dateArgumentText})`,
+                    );
+                  },
+                });
+                return;
+              }
+            }
+          }
+        }
+      },
+
+      // Detect new Date() constructor patterns for month boundaries
+      NewExpression(node: TSESTree.NewExpression) {
+        // Detect millisecond hacks if enabled
+        if (
+          (options?.detectHacks ?? true) &&
+          node.callee.type === "Identifier" &&
+          node.callee.name === "Date" &&
+          node.arguments.length === 1
+        ) {
+          const argument = node.arguments[0];
+
+          // Check for: new Date(+date + 86400000) or new Date(+date - ...)
+          if (
+            argument &&
+            argument.type === "BinaryExpression" &&
+            (argument.operator === "+" || argument.operator === "-")
+          ) {
+            // Left side should be unary + with a date-like expression
+            const left = argument.left;
+            const right = argument.right;
+
+            // Pattern: +date + 86400000 (adding days)
+            if (
+              left.type === "UnaryExpression" &&
+              left.operator === "+" &&
+              right.type === "Literal" &&
+              typeof right.value === "number"
+            ) {
+              const milliseconds = right.value;
+              const days = milliseconds / MS_PER_DAY;
+
+              // Check if it's a whole number of days
+              if (
+                argument.operator === "+" &&
+                Number.isInteger(days) &&
+                days > 0
+              ) {
+                const dateExpression = sourceCode.getText(left.argument);
+                context.report({
+                  node,
+                  messageId: "useAddDays",
+                  fix(fixer) {
+                    return createImportAndReplaceFix(
+                      context,
+                      fixer,
+                      ["addDays"],
+                      node,
+                      `addDays(${dateExpression}, ${days})`,
+                    );
+                  },
+                });
+                return;
+              }
+            }
+
+            // Pattern: +date - date.getDay() * 86400000 (week start)
+            if (
+              left.type === "UnaryExpression" &&
+              left.operator === "+" &&
+              argument.operator === "-" &&
+              right.type === "BinaryExpression" &&
+              right.operator === "*"
+            ) {
+              // Check if right side is: something.getDay() * 86400000
+              const multiplier = right.right;
+              const getDayCall = right.left;
+
+              if (
+                multiplier.type === "Literal" &&
+                multiplier.value === MS_PER_DAY &&
+                getDayCall.type === "CallExpression" &&
+                getDayCall.callee.type === "MemberExpression" &&
+                getDayCall.callee.property.type === "Identifier" &&
+                getDayCall.callee.property.name === "getDay"
+              ) {
+                // This is a week start calculation
+                const dateExpression = sourceCode.getText(left.argument);
+                const weekStartsOn = options?.weekStartsOn ?? 1;
+
+                context.report({
+                  node,
+                  messageId: "useStartOfWeek",
+                  fix(fixer) {
+                    return createImportAndReplaceFix(
+                      context,
+                      fixer,
+                      ["startOfWeek"],
+                      node,
+                      `startOfWeek(${dateExpression}, { weekStartsOn: ${weekStartsOn} })`,
+                    );
+                  },
+                });
+                return;
+              }
+            }
+          }
+        }
+
+        if (
+          node.callee.type === "Identifier" &&
+          node.callee.name === "Date" &&
+          node.arguments.length === 3
+        ) {
+          const [yearArgument, monthArgument, dateArgument] = node.arguments;
+
+          // Check for end of month: new Date(year, month + 1, 0)
+          if (
+            dateArgument?.type === "Literal" &&
+            dateArgument.value === 0 &&
+            monthArgument?.type === "BinaryExpression" &&
+            monthArgument.operator === "+" &&
+            monthArgument.right.type === "Literal" &&
+            monthArgument.right.value === 1
+          ) {
+            if (!yearArgument) return;
+
+            context.report({
+              node,
+              messageId: "useEndOfMonth",
+              fix(fixer) {
+                // Get the base month expression (left side of +)
+                const baseMonthText = sourceCode.getText(monthArgument.left);
+                const yearText = sourceCode.getText(yearArgument);
+                return createImportAndReplaceFix(
+                  context,
+                  fixer,
+                  ["endOfMonth"],
+                  node,
+                  `endOfMonth(new Date(${yearText}, ${baseMonthText}))`,
+                );
+              },
+            });
+            return;
+          }
+
+          // Check for start of month: new Date(year, month, 1)
+          if (
+            dateArgument?.type === "Literal" &&
+            dateArgument.value === 1 &&
+            monthArgument?.type !== "BinaryExpression" && // Simple month reference, not an expression
+            yearArgument
+          ) {
+            context.report({
+              node,
+              messageId: "useStartOfMonth",
+              fix(fixer) {
+                const yearText = sourceCode.getText(yearArgument);
+                const monthText = sourceCode.getText(monthArgument);
+                return createImportAndReplaceFix(
+                  context,
+                  fixer,
+                  ["startOfMonth"],
+                  node,
+                  `startOfMonth(new Date(${yearText}, ${monthText}))`,
+                );
+              },
+            });
+            return;
+          }
+        }
+      },
+    };
+  },
+});
+
+/**
+ * Checks if time components match a start-of-day pattern (00:00:00.000)
+ */
+function isStartOfDayPattern(
+  hours: number | undefined,
+  minutes: number | undefined,
+  seconds: number | undefined,
+  ms: number | undefined | null,
+): boolean {
+  return hours === 0 && minutes === 0 && seconds === 0 && ms === 0;
+}
+
+/**
+ * Checks if time components match an end-of-day pattern based on heuristic
+ * @param heuristic - Detection strictness level
+ * @returns true if pattern matches EOD based on heuristic
+ */
+function isEndOfDayPattern(
+  hours: number | undefined,
+  minutes: number | undefined,
+  seconds: number | undefined,
+  ms: number | undefined | null,
+  heuristic: EndOfDayHeuristic,
+): boolean {
+  // Strict: only 23:59:59.999
+  if (hours === 23 && minutes === 59 && seconds === 59 && ms === 999) {
+    return true;
+  }
+
+  // Lenient/Aggressive: 23:59:59 with ms===0 or undefined/null
+  if (
+    heuristic !== "strict" &&
+    hours === 23 &&
+    minutes === 59 &&
+    seconds === 59 &&
+    (ms === 0 || ms === undefined || ms === null)
+  ) {
+    return true;
+  }
+
+  // Aggressive: near-EOD (23:58 or 23:59)
+  if (
+    heuristic === "aggressive" &&
+    hours === 23 &&
+    minutes !== undefined &&
+    minutes >= 58
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Checks if time components are "near" end-of-day (23:58 or later)
+ * Used for suggesting endOfDay even when not auto-fixing
+ */
+function isNearEndOfDay(
+  hours: number | undefined,
+  minutes: number | undefined,
+): boolean {
+  return hours === 23 && minutes !== undefined && minutes >= 58;
+}
+
+/**
+ * Check if a node has a type that we should skip analyzing
+ * (any, unknown, or not a Date type)
+ */
+function shouldSkipType(
+  node: TSESTree.Node,
+  checker: import("typescript").TypeChecker | undefined,
+  services: ReturnType<typeof ESLintUtils.getParserServices>,
+): boolean {
+  if (!checker) return false;
+
+  try {
+    const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+    const type = checker.getTypeAtLocation(tsNode);
+    const typeString = checker.typeToString(type);
+
+    // Skip if type is any or unknown
+    if (typeString === "any" || typeString === "unknown") {
+      return true;
+    }
+  } catch {
+    // If we can't get type info, proceed with the check
+    return false;
+  }
+
+  return false;
+}
+
+/**
+ * Check if a function call is a date-fns import
+ */
+function isDateFnsFunction(
+  node: TSESTree.CallExpression,
+  functionName: string,
+  dateFnsImports: Map<string, string>,
+): boolean {
+  if (node.callee.type !== "Identifier") return false;
+  const calleeName = node.callee.name;
+  const importedName = dateFnsImports.get(calleeName);
+  return importedName === functionName;
+}
+
+// Helper to analyze nested setter chains
+function analyzeSetterChain(node: TSESTree.CallExpression):
+  | {
+      hours: number | undefined;
+      minutes: number | undefined;
+      seconds: number | undefined;
+      milliseconds: number | undefined;
+      dateArgument: TSESTree.Node;
+    }
+  | undefined {
+  const values = {
+    hours: undefined as number | undefined,
+    minutes: undefined as number | undefined,
+    seconds: undefined as number | undefined,
+    milliseconds: undefined as number | undefined,
+  };
+
+  let currentNode: TSESTree.Node = node;
+  let dateArgument: TSESTree.Node | undefined = undefined;
+
+  // Walk down the chain
+  while (
+    currentNode.type === "CallExpression" &&
+    currentNode.callee.type === "Identifier"
+  ) {
+    const functionName = currentNode.callee.name;
+    const nodeArguments: readonly TSESTree.Node[] = currentNode.arguments;
+
+    // Extract the value being set
+    // For date-fns setters: setHours(date, hours) - value is at index 1
+    switch (functionName) {
+      case "setHours": {
+        const argument = nodeArguments[1];
+        if (
+          argument?.type === "Literal" &&
+          typeof argument.value === "number"
+        ) {
+          values.hours = argument.value;
+        }
+        break;
+      }
+      case "setMinutes": {
+        const argument = nodeArguments[1];
+        if (
+          argument?.type === "Literal" &&
+          typeof argument.value === "number"
+        ) {
+          values.minutes = argument.value;
+        }
+        break;
+      }
+      case "setSeconds": {
+        const argument = nodeArguments[1];
+        if (
+          argument?.type === "Literal" &&
+          typeof argument.value === "number"
+        ) {
+          values.seconds = argument.value;
+        }
+        break;
+      }
+      case "setMilliseconds": {
+        const argument = nodeArguments[1];
+        if (
+          argument?.type === "Literal" &&
+          typeof argument.value === "number"
+        ) {
+          values.milliseconds = argument.value;
+        }
+        break;
+      }
+    }
+
+    // Move to the first argument (the date, which might be another setter call)
+    if (nodeArguments[0]) {
+      currentNode = nodeArguments[0];
+    } else {
+      break;
+    }
+  }
+
+  // The final node is the date argument
+  dateArgument = currentNode;
+
+  return dateArgument ? { ...values, dateArgument } : undefined;
+}

--- a/src/rules/no-plain-boundary-math/index.ts
+++ b/src/rules/no-plain-boundary-math/index.ts
@@ -58,7 +58,6 @@ const DATE_SETTERS = new Set([
 // Time constants in milliseconds
 const MS_PER_DAY = 86_400_000;
 
-
 export default createRule<Options, MessageIds>({
   name: "no-plain-boundary-math",
   meta: {
@@ -147,6 +146,14 @@ export default createRule<Options, MessageIds>({
       },
     ],
   },
+  defaultOptions: [
+    {
+      weekStartsOn: 1,
+      detectHacks: true,
+      suggestOnlyForAmbiguity: true,
+      endOfDayHeuristic: "lenient",
+    },
+  ],
   create(context, [options]) {
     const sourceCode = context.sourceCode;
     const services = ESLintUtils.getParserServices(context);

--- a/src/rules/no-plain-boundary-math/index.ts
+++ b/src/rules/no-plain-boundary-math/index.ts
@@ -147,14 +147,6 @@ export default createRule<Options, MessageIds>({
       },
     ],
   },
-  defaultOptions: [
-    {
-      weekStartsOn: 1,
-      detectHacks: true,
-      suggestOnlyForAmbiguity: true,
-      endOfDayHeuristic: "lenient",
-    },
-  ],
   create(context, [options]) {
     const sourceCode = context.sourceCode;
     const services = ESLintUtils.getParserServices(context);

--- a/test/rules/no-plain-boundary-math.test.ts
+++ b/test/rules/no-plain-boundary-math.test.ts
@@ -1,0 +1,462 @@
+import test from "node:test";
+import { tester } from "../_setup.ts";
+import rule from "../../dist/rules/no-plain-boundary-math/index.js";
+
+test("no-plain-boundary-math: valid cases", () => {
+  tester.run("no-plain-boundary-math", rule, {
+    valid: [
+      // Already using date-fns boundaries
+      `import { startOfDay } from 'date-fns'; const d = startOfDay(new Date());`,
+      `import { endOfDay } from 'date-fns'; const e = endOfDay(new Date());`,
+      `import { startOfWeek } from 'date-fns'; const w = startOfWeek(new Date(), { weekStartsOn: 1 });`,
+      `import { endOfMonth } from 'date-fns'; const m = endOfMonth(new Date());`,
+      `import { startOfQuarter } from 'date-fns'; const q = startOfQuarter(new Date());`,
+      `import { endOfYear } from 'date-fns'; const y = endOfYear(new Date());`,
+
+      // Composed boundaries (already optimal)
+      `import { endOfDay, addWeeks } from 'date-fns'; const d = endOfDay(addWeeks(new Date(), 1));`,
+      `import { startOfMonth, subMonths } from 'date-fns'; const m = startOfMonth(subMonths(new Date(), 1));`,
+
+      // Non-boundary Date usage
+      `const d = new Date(); d.setHours(9);`, // business hour
+      `const d = new Date(); d.setMinutes(30);`, // specific time
+      `const d = new Date(); d.setHours(14, 30);`, // specific time
+      `const d = new Date(2024, 5, 15);`, // specific date
+      `const d = new Date(2024, 5, 15, 14, 30);`, // specific date/time
+
+      // Non-boundary date-fns setters
+      `import { set } from 'date-fns'; const d = set(new Date(), { year: 2024, month: 5 });`,
+      `import { set } from 'date-fns'; const d = set(new Date(), { hours: 9, minutes: 30 });`,
+      `import { setHours } from 'date-fns'; const d = setHours(new Date(), 14);`,
+
+      // Shadowed Date
+      `function foo(Date) { const d = new Date(2024, 1, 0); return d; }`,
+      `{ const Date = class {}; const d = new Date(2024, 1, 0); }`,
+
+      // Non-date-fns set/setHours
+      `import { set } from 'lodash'; set({}, "hours", 0);`,
+      `const obj = { setHours: () => {} }; obj.setHours(0);`,
+
+      // TypeScript unknown/any (can't analyze)
+      `declare const d: unknown; d.setHours(0, 0, 0, 0);`,
+      `const d: any = getDate(); d.setHours(0, 0, 0, 0);`,
+
+      // Complex expressions we don't handle
+      `const d = new Date(); d.setHours(config?.startHour || 0, 0, 0, 0);`,
+      `const d = new Date(); d.setHours(Math.random() > 0.5 ? 0 : 23);`,
+    ],
+    invalid: [],
+  });
+});
+
+test("no-plain-boundary-math: plain Date start of day", () => {
+  tester.run("no-plain-boundary-math", rule, {
+    valid: [],
+    invalid: [
+      // Basic start of day pattern
+      {
+        code: `const date = new Date();\ndate.setHours(0, 0, 0, 0);`,
+        output: `import { startOfDay } from 'date-fns';\nconst date = new Date();\nstartOfDay(date);`,
+        errors: [{ messageId: "useStartOfDay" }],
+      },
+
+      // Start of day on identifier
+      {
+        code: `declare const d: Date;\nd.setHours(0, 0, 0, 0);`,
+        output: `import { startOfDay } from 'date-fns';\ndeclare const d: Date;\nstartOfDay(d);`,
+        errors: [{ messageId: "useStartOfDay" }],
+      },
+
+      // Start of day in expression
+      {
+        code: `const result = new Date().setHours(0, 0, 0, 0);`,
+        output: `import { startOfDay } from 'date-fns';\nconst result = +startOfDay(new Date());`,
+        errors: [{ messageId: "useStartOfDay" }],
+      },
+    ],
+  });
+});
+
+test("no-plain-boundary-math: plain Date end of day (strict mode)", () => {
+  tester.run("no-plain-boundary-math", rule, {
+    valid: [],
+    invalid: [
+      // Canonical EOD with milliseconds
+      {
+        code: `const d = new Date();\nd.setHours(23, 59, 59, 999);`,
+        output: `import { endOfDay } from 'date-fns';\nconst d = new Date();\nendOfDay(d);`,
+        options: [{ endOfDayHeuristic: "strict" }],
+        errors: [{ messageId: "useEndOfDay" }],
+      },
+
+      // EOD without milliseconds should NOT autofix in strict mode
+      {
+        code: `const d = new Date();\nd.setHours(23, 59, 59);`,
+        options: [{ endOfDayHeuristic: "strict" }],
+        errors: [
+          {
+            messageId: "nearEndOfDay",
+            suggestions: [
+              {
+                messageId: "suggestEndOfDay",
+                output: `import { endOfDay } from 'date-fns';\nconst d = new Date();\nendOfDay(d);`,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+});
+
+test("no-plain-boundary-math: plain Date end of day (lenient mode)", () => {
+  tester.run("no-plain-boundary-math", rule, {
+    valid: [],
+    invalid: [
+      // Canonical EOD with milliseconds - autofix
+      {
+        code: `const d = new Date();\nd.setHours(23, 59, 59, 999);`,
+        output: `import { endOfDay } from 'date-fns';\nconst d = new Date();\nendOfDay(d);`,
+        options: [{ endOfDayHeuristic: "lenient" }],
+        errors: [{ messageId: "useEndOfDay" }],
+      },
+
+      // EOD without milliseconds - autofix in lenient
+      {
+        code: `const d = new Date();\nd.setHours(23, 59, 59);`,
+        output: `import { endOfDay } from 'date-fns';\nconst d = new Date();\nendOfDay(d);`,
+        options: [{ endOfDayHeuristic: "lenient" }],
+        errors: [{ messageId: "useEndOfDay" }],
+      },
+
+      // Near-EOD should still suggest in lenient
+      {
+        code: `const d = new Date();\nd.setHours(23, 58);`,
+        options: [{ endOfDayHeuristic: "lenient" }],
+        errors: [
+          {
+            messageId: "nearEndOfDay",
+            suggestions: [
+              {
+                messageId: "suggestEndOfDay",
+                output: `import { endOfDay } from 'date-fns';\nconst d = new Date();\nendOfDay(d);`,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+});
+
+test("no-plain-boundary-math: plain Date end of day (aggressive mode)", () => {
+  tester.run("no-plain-boundary-math", rule, {
+    valid: [],
+    invalid: [
+      // Canonical EOD - autofix
+      {
+        code: `const d = new Date();\nd.setHours(23, 59, 59, 999);`,
+        output: `import { endOfDay } from 'date-fns';\nconst d = new Date();\nendOfDay(d);`,
+        options: [{ endOfDayHeuristic: "aggressive" }],
+        errors: [{ messageId: "useEndOfDay" }],
+      },
+
+      // Near-EOD - autofix in aggressive
+      {
+        code: `const d = new Date();\nd.setHours(23, 58);`,
+        output: `import { endOfDay } from 'date-fns';\nconst d = new Date();\nendOfDay(d);`,
+        options: [{ endOfDayHeuristic: "aggressive" }],
+        errors: [{ messageId: "useEndOfDay" }],
+      },
+
+      // 23:59 without seconds - autofix in aggressive
+      {
+        code: `const d = new Date();\nd.setHours(23, 59);`,
+        output: `import { endOfDay } from 'date-fns';\nconst d = new Date();\nendOfDay(d);`,
+        options: [{ endOfDayHeuristic: "aggressive" }],
+        errors: [{ messageId: "useEndOfDay" }],
+      },
+    ],
+  });
+});
+
+test("no-plain-boundary-math: date-fns set() to start of day", () => {
+  tester.run("no-plain-boundary-math", rule, {
+    valid: [
+      // With other properties (not a boundary)
+      `import { set } from 'date-fns';\nconst s = set(d, { year: 2024, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 });`,
+    ],
+    invalid: [
+      // Basic set() to start of day
+      {
+        code: `import { set } from 'date-fns';\nconst s = set(d, { hours: 0, minutes: 0, seconds: 0, milliseconds: 0 });`,
+        output: `import { set, startOfDay } from 'date-fns';\nconst s = startOfDay(d);`,
+        errors: [{ messageId: "useStartOfDay" }],
+      },
+    ],
+  });
+});
+
+test("no-plain-boundary-math: date-fns setter chains to start of day", () => {
+  tester.run("no-plain-boundary-math", rule, {
+    valid: [],
+    invalid: [
+      // Setter chain to start of day
+      {
+        code: `import { setHours, setMinutes, setSeconds, setMilliseconds } from 'date-fns';\nconst s = setHours(setMinutes(setSeconds(setMilliseconds(d, 0), 0), 0), 0);`,
+        output: `import { setHours, setMilliseconds, setMinutes, setSeconds, startOfDay } from 'date-fns';\nconst s = startOfDay(d);`,
+        errors: [{ messageId: "useStartOfDay" }],
+      },
+
+      // Partial chain (only hours and minutes)
+      {
+        code: `import { setHours, setMinutes } from 'date-fns';\nconst s = setHours(setMinutes(d, 0), 0);`,
+        output: `import { setHours, setMinutes, startOfHour } from 'date-fns';\nconst s = startOfHour(d);`,
+        errors: [{ messageId: "useStartOfHour" }],
+      },
+    ],
+  });
+});
+
+test("no-plain-boundary-math: date-fns set() to end of day", () => {
+  tester.run("no-plain-boundary-math", rule, {
+    valid: [],
+    invalid: [
+      // Canonical EOD in strict mode
+      {
+        code: `import { set } from 'date-fns';\nconst e = set(d, { hours: 23, minutes: 59, seconds: 59, milliseconds: 999 });`,
+        output: `import { endOfDay, set } from 'date-fns';\nconst e = endOfDay(d);`,
+        options: [{ endOfDayHeuristic: "strict" }],
+        errors: [{ messageId: "useEndOfDay" }],
+      },
+
+      // EOD without milliseconds in lenient mode
+      {
+        code: `import { set } from 'date-fns';\nconst e = set(d, { hours: 23, minutes: 59, seconds: 59 });`,
+        output: `import { endOfDay, set } from 'date-fns';\nconst e = endOfDay(d);`,
+        options: [{ endOfDayHeuristic: "lenient" }],
+        errors: [{ messageId: "useEndOfDay" }],
+      },
+
+      // Near-EOD in aggressive mode
+      {
+        code: `import { set } from 'date-fns';\nconst e = set(d, { hours: 23, minutes: 58 });`,
+        output: `import { endOfDay, set } from 'date-fns';\nconst e = endOfDay(d);`,
+        options: [{ endOfDayHeuristic: "aggressive" }],
+        errors: [{ messageId: "useEndOfDay" }],
+      },
+    ],
+  });
+});
+
+test("no-plain-boundary-math: date-fns setter chains to end of day", () => {
+  tester.run("no-plain-boundary-math", rule, {
+    valid: [],
+    invalid: [
+      // Setter chain to EOD (lenient)
+      {
+        code: `import { setHours, setMinutes, setSeconds } from 'date-fns';\nconst e = setSeconds(setMinutes(setHours(d, 23), 59), 59);`,
+        output: `import { endOfDay, setHours, setMinutes, setSeconds } from 'date-fns';\nconst e = endOfDay(d);`,
+        options: [{ endOfDayHeuristic: "lenient" }],
+        errors: [{ messageId: "useEndOfDay" }],
+      },
+    ],
+  });
+});
+
+test("no-plain-boundary-math: month boundaries", () => {
+  tester.run("no-plain-boundary-math", rule, {
+    valid: [],
+    invalid: [
+      // End of month (day 0 trick)
+      {
+        code: `const eom = new Date(year, month + 1, 0);`,
+        output: `import { endOfMonth } from 'date-fns';\nconst eom = endOfMonth(new Date(year, month));`,
+        errors: [{ messageId: "useEndOfMonth" }],
+      },
+
+      // Start of month
+      {
+        code: `const som = new Date(year, month, 1);`,
+        output: `import { startOfMonth } from 'date-fns';\nconst som = startOfMonth(new Date(year, month));`,
+        errors: [{ messageId: "useStartOfMonth" }],
+      },
+
+      // Start of month with set()
+      {
+        code: `import { set } from 'date-fns';\nconst som = set(d, { date: 1, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 });`,
+        output: `import { set, startOfMonth } from 'date-fns';\nconst som = startOfMonth(d);`,
+        errors: [{ messageId: "useStartOfMonth" }],
+      },
+    ],
+  });
+});
+
+test("no-plain-boundary-math: year boundaries", () => {
+  tester.run("no-plain-boundary-math", rule, {
+    valid: [],
+    invalid: [
+      // Start of year
+      {
+        code: `import { set } from 'date-fns';\nconst s = set(d, { month: 0, date: 1, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 });`,
+        output: `import { set, startOfYear } from 'date-fns';\nconst s = startOfYear(d);`,
+        errors: [{ messageId: "useStartOfYear" }],
+      },
+
+      // End of year (strict mode)
+      {
+        code: `import { set } from 'date-fns';\nconst e = set(d, { month: 11, date: 31, hours: 23, minutes: 59, seconds: 59, milliseconds: 999 });`,
+        output: `import { endOfYear, set } from 'date-fns';\nconst e = endOfYear(d);`,
+        options: [{ endOfDayHeuristic: "strict" }],
+        errors: [{ messageId: "useEndOfYear" }],
+      },
+    ],
+  });
+});
+
+test("no-plain-boundary-math: hour/minute/second boundaries", () => {
+  tester.run("no-plain-boundary-math", rule, {
+    valid: [],
+    invalid: [
+      // Start of hour
+      {
+        code: `const d = new Date();\nd.setMinutes(0, 0, 0);`,
+        output: `import { startOfHour } from 'date-fns';\nconst d = new Date();\nstartOfHour(d);`,
+        errors: [{ messageId: "useStartOfHour" }],
+      },
+
+      // Start of minute
+      {
+        code: `const d = new Date();\nd.setSeconds(0, 0);`,
+        output: `import { startOfMinute } from 'date-fns';\nconst d = new Date();\nstartOfMinute(d);`,
+        errors: [{ messageId: "useStartOfMinute" }],
+      },
+
+      // Start of second
+      {
+        code: `const d = new Date();\nd.setMilliseconds(0);`,
+        output: `import { startOfSecond } from 'date-fns';\nconst d = new Date();\nstartOfSecond(d);`,
+        errors: [{ messageId: "useStartOfSecond" }],
+      },
+    ],
+  });
+});
+
+test("no-plain-boundary-math: import management", () => {
+  tester.run("no-plain-boundary-math", rule, {
+    valid: [],
+    invalid: [
+      // Merge with existing date-fns import
+      {
+        code: `import { format } from 'date-fns';\nconst date = new Date();\ndate.setHours(0, 0, 0, 0);`,
+        output: `import { format, startOfDay } from 'date-fns';\nconst date = new Date();\nstartOfDay(date);`,
+        errors: [{ messageId: "useStartOfDay" }],
+      },
+
+      // Keep setter imports and add boundary helper
+      {
+        code: `import { setHours, setMinutes, format } from 'date-fns';\nconst s = setHours(setMinutes(d, 0), 0);`,
+        output: `import { format, setHours, setMinutes, startOfHour } from 'date-fns';\nconst s = startOfHour(d);`,
+        errors: [{ messageId: "useStartOfHour" }],
+      },
+    ],
+  });
+});
+
+test("no-plain-boundary-math: composition with existing date-fns", () => {
+  tester.run("no-plain-boundary-math", rule, {
+    valid: [],
+    invalid: [
+      // Composition: set() after addDays()
+      {
+        code: `import { addDays, set } from 'date-fns';\nconst next = set(addDays(d, 7), { hours: 0, minutes: 0, seconds: 0, milliseconds: 0 });`,
+        output: `import { addDays, set, startOfDay } from 'date-fns';\nconst next = startOfDay(addDays(d, 7));`,
+        errors: [{ messageId: "useStartOfDay" }],
+      },
+    ],
+  });
+});
+
+test("no-plain-boundary-math: suggestions for ambiguous patterns", () => {
+  tester.run("no-plain-boundary-math", rule, {
+    valid: [],
+    invalid: [
+      // Variable hour value
+      {
+        code: `const d = new Date();\nd.setHours(startHour, 0, 0, 0);`,
+        errors: [
+          {
+            messageId: "possibleBoundary",
+            suggestions: [
+              {
+                messageId: "suggestStartOfDay",
+                output: `import { startOfDay } from 'date-fns';\nconst d = new Date();\nstartOfDay(d);`,
+              },
+            ],
+          },
+        ],
+      },
+
+      // Complex expression
+      {
+        code: `const d = new Date();\nd.setHours(config.boundary ? 0 : 23, 0, 0, 0);`,
+        errors: [
+          {
+            messageId: "complexBoundaryExpression",
+            suggestions: [
+              {
+                messageId: "suggestStartOrEnd",
+                output: `import { endOfDay, startOfDay } from 'date-fns';\nconst d = new Date();\nconfig.boundary ? startOfDay(d) : endOfDay(d);`,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+});
+
+test("no-plain-boundary-math: edge cases", () => {
+  tester.run("no-plain-boundary-math", rule, {
+    valid: [
+      // Shadowed Date constructor - should not trigger
+      `function test(Date) { const d = new Date(2024, 1, 0); return d; }`,
+
+      // Shadowed date-fns set
+      `import { set as lodashSet } from 'lodash'; lodashSet(obj, "hours", 0);`,
+
+      // TypeScript any type - should not trigger
+      `const date: any = getDate(); date.setHours(0, 0, 0, 0);`,
+    ],
+    invalid: [],
+  });
+});
+
+test("no-plain-boundary-math: detectHacks option", () => {
+  tester.run("no-plain-boundary-math", rule, {
+    valid: [
+      // With detectHacks disabled, millisecond math is ignored
+      {
+        code: `const tomorrow = new Date(+date + 86400000);`,
+        options: [{ detectHacks: false }],
+      },
+    ],
+    invalid: [
+      // With detectHacks enabled (default), millisecond math is caught
+      {
+        code: `const tomorrow = new Date(+date + 86400000);`,
+        output: `import { addDays } from 'date-fns';\nconst tomorrow = addDays(date, 1);`,
+        options: [{ detectHacks: true }],
+        errors: [{ messageId: "useAddDays" }],
+      },
+
+      // Week millisecond math
+      {
+        code: `const weekStart = new Date(+date - date.getDay() * 86400000);`,
+        output: `import { startOfWeek } from 'date-fns';\nconst weekStart = startOfWeek(date, { weekStartsOn: 0 });`,
+        options: [{ detectHacks: true, weekStartsOn: 0 }],
+        errors: [{ messageId: "useStartOfWeek" }],
+      },
+    ],
+  });
+});


### PR DESCRIPTION
This pull request introduces a new ESLint rule to the `eslint-plugin-date-fns` package, designed to prevent manual date boundary calculations and encourage the use of date-fns helper functions. It also updates the documentation, configuration, and registry to support this new rule, and includes minor improvements to comments in an existing rule.

**New Rule Addition and Ecosystem Updates:**

* **Rule Implementation and Documentation**
  - Added the new `no-plain-boundary-math` rule, which detects and prevents manual date boundary calculations (such as using `setHours` for start/end of day) and suggests or autofixes them to use date-fns helpers like `startOfDay`, `endOfMonth`, etc. Comprehensive documentation was created in `docs/rules/no-plain-boundary-math.md`, including usage examples, options, and configuration details.
  - Registered the new rule in the plugin's rule index (`src/rules/index.ts`) and updated the recommended configuration to enable it by default (`src/configs/recommended.ts`). [[1]](diffhunk://#diff-322e2e2bfe9e4fb7c3471bb9d4f7de07372589c87c141420912ed6b00631237cR10) [[2]](diffhunk://#diff-322e2e2bfe9e4fb7c3471bb9d4f7de07372589c87c141420912ed6b00631237cR25) [[3]](diffhunk://#diff-ee7ac2e490d03c854fe269207dff9dd802bace92ee45f82870bda24315d98075R16)
  - Updated the main README to describe the new rule and link to its documentation.

**Package and Maintenance:**

* **Version Bump**
  - Updated the package version in `package.json` from `0.1.0` to `0.2.0` to reflect the addition of the new rule.

**Minor Improvements:**

* **Comment Clarifications**
  - Simplified comments in the `no-date-mutation` rule for clarity regarding temporary variable usage during autofix logic. [[1]](diffhunk://#diff-bb35e7534417eacf62749934e999bf83776d83df021a02159028996a810f9b94L794-R794) [[2]](diffhunk://#diff-bb35e7534417eacf62749934e999bf83776d83df021a02159028996a810f9b94L841-R841)