### PR TITLE
feat(require-isvalid-after): include assertions as a way to validate

### DIFF
--- a/docs/rules/require-isvalid-after-parse.md
+++ b/docs/rules/require-isvalid-after-parse.md
@@ -173,6 +173,7 @@ The rule recognizes assertion-based validation commonly used in tests. These pat
 - `expect(isValid(date)).toBe(false)` - asserting invalid, not validating
 - `expect(isValid(date)).toBeFalsy()` - asserting invalid
 - `expect(isValid(date)).toEqual(false)` - asserting invalid
+- `expect(isValid(date)).toStrictEqual(false)` - asserting invalid
 - `expect(isValid(date)).to.be.false` (Chai-style) - asserting invalid
 
 ## Suggestion Behavior

--- a/docs/rules/require-isvalid-after-parse.md
+++ b/docs/rules/require-isvalid-after-parse.md
@@ -132,7 +132,48 @@ function quickFormat(dateStr) {
 function directUse(input) {
   return isValid(parseISO(input)) ? parseISO(input) : null;
 }
+
+// Assertion-based validation in tests
+function testDateParsing(input, referenceDate) {
+  const date = parseISO(input);
+  expect(isValid(date)).toBe(true);  // Validates before subsequent usage
+  expect(differenceInDays(date, referenceDate)).toBe(7);
+  expect(date.getFullYear()).toBe(2025);
+}
+
+// Node.js assert() validation
+function processWithAssert(input) {
+  const date = parseISO(input);
+  assert(isValid(date));  // Throws if invalid
+  return date.toISOString();
+}
+
+// Chai-style assertion
+function testWithChai(input) {
+  const date = parseISO(input);
+  expect(isValid(date)).to.be.true;
+  return format(date, 'yyyy-MM-dd');
+}
 ```
+
+### Assertion Patterns
+
+The rule recognizes assertion-based validation commonly used in tests. These patterns count as valid guards when they assert the date **is** valid:
+
+**✅ Valid assertion patterns (count as validation):**
+- `expect(isValid(date)).toBe(true)`
+- `expect(isValid(date)).toBeTruthy()`
+- `expect(isValid(date)).toEqual(true)`
+- `expect(isValid(date)).toStrictEqual(true)`
+- `expect(isValid(date)).to.be.true` (Chai-style)
+- `assert(isValid(date))`
+- `assert.ok(isValid(date))`
+
+**❌ Invalid assertion patterns (do NOT count as validation):**
+- `expect(isValid(date)).toBe(false)` - asserting invalid, not validating
+- `expect(isValid(date)).toBeFalsy()` - asserting invalid
+- `expect(isValid(date)).toEqual(false)` - asserting invalid
+- `expect(isValid(date)).to.be.false` (Chai-style) - asserting invalid
 
 ## Suggestion Behavior
 

--- a/test/rules/require-isvalid-after-parse.test.ts
+++ b/test/rules/require-isvalid-after-parse.test.ts
@@ -162,6 +162,86 @@ function checkValid(s: string): boolean {
 }
 `,
 
+      // ✅ Assertion validation in test - isValid called before date usage
+      `
+import { parseISO, isValid, differenceInDays } from 'date-fns';
+declare function expect(value: unknown): { toBe(expected: unknown): void };
+function testDateOffset(input: string, referenceDate: Date) {
+  const resultDate = parseISO(input);
+  expect(isValid(resultDate)).toBe(true);
+  expect(differenceInDays(resultDate, referenceDate)).toBe(7);
+  expect(resultDate.getDate()).toBe(22);
+  expect(resultDate.getMonth()).toBe(5);
+  expect(resultDate.getFullYear()).toBe(2025);
+}
+`,
+
+      // ✅ Node assert() validation
+      `
+import { parseISO, isValid } from 'date-fns';
+declare function assert(value: unknown): asserts value;
+function processDate(input: string) {
+  const d = parseISO(input);
+  assert(isValid(d));
+  return d.getTime();
+}
+`,
+
+      // ✅ assert.ok() validation
+      `
+import { parseISO, isValid } from 'date-fns';
+declare const assert: { ok(value: unknown): asserts value };
+function processDate(input: string) {
+  const d = parseISO(input);
+  assert.ok(isValid(d));
+  return d.toISOString();
+}
+`,
+
+      // ✅ Chai-style deep chained assertion - to.be.true
+      `
+import { parseISO, isValid } from 'date-fns';
+declare function expect(value: unknown): { to: { be: { true: void } } };
+function testDate(input: string) {
+  const d = parseISO(input);
+  expect(isValid(d)).to.be.true;
+  return d.getFullYear();
+}
+`,
+
+      // ✅ toBeTruthy() style assertion
+      `
+import { parseISO, isValid } from 'date-fns';
+declare function expect(value: unknown): { toBeTruthy(): void };
+function testDate(input: string) {
+  const d = parseISO(input);
+  expect(isValid(d)).toBeTruthy();
+  return d.getMonth();
+}
+`,
+
+      // ✅ toEqual(true) style assertion
+      `
+import { parseISO, isValid } from 'date-fns';
+declare function expect(value: unknown): { toEqual(expected: unknown): void };
+function testDate(input: string) {
+  const d = parseISO(input);
+  expect(isValid(d)).toEqual(true);
+  return d.getDate();
+}
+`,
+
+      // ✅ toStrictEqual(true) style assertion
+      `
+import { parseISO, isValid } from 'date-fns';
+declare function expect(value: unknown): { toStrictEqual(expected: unknown): void };
+function testDate(input: string) {
+  const d = parseISO(input);
+  expect(isValid(d)).toStrictEqual(true);
+  return d.getHours();
+}
+`,
+
       // ✅ Complex logical validation
       `
 import { parseISO, isValid } from 'date-fns';
@@ -1233,6 +1313,234 @@ if (!isValid(userDate)) {
 }
 
   return [validConstant, userDate];
+}
+`,
+              },
+            ],
+          },
+        ],
+      },
+
+      // ❌ Using parsed date before validation - isValid check after date methods
+      {
+        code: `
+import { parseISO, isValid, differenceInDays } from 'date-fns';
+function getDateOffset(input: string, referenceDate: Date) {
+  const result = parseISO(input);
+  const daysDiff = differenceInDays(result, referenceDate);
+  const day = result.getDate();
+  const month = result.getMonth();
+  const year = result.getFullYear();
+  const valid = isValid(result);
+  return { daysDiff, day, month, year, valid };
+}
+`,
+        errors: [
+          {
+            messageId: "requireIsValid",
+            suggestions: [
+              {
+                messageId: "suggestGuard",
+                output: `
+import { parseISO, isValid, differenceInDays } from 'date-fns';
+function getDateOffset(input: string, referenceDate: Date) {
+  const result = parseISO(input);
+if (!isValid(result)) {
+  // TODO: handle invalid date
+}
+
+  const daysDiff = differenceInDays(result, referenceDate);
+  const day = result.getDate();
+  const month = result.getMonth();
+  const year = result.getFullYear();
+  const valid = isValid(result);
+  return { daysDiff, day, month, year, valid };
+}
+`,
+              },
+            ],
+          },
+        ],
+      },
+
+      // ❌ Using isValid in assertion after date usage - validation comes too late
+      {
+        code: `
+import { parseISO, isValid, differenceInDays } from 'date-fns';
+declare function expect(value: unknown): { toBe(expected: unknown): void };
+function testDateOffset(input: string, referenceDate: Date) {
+  const resultDate = parseISO(input);
+  expect(differenceInDays(resultDate, referenceDate)).toBe(7);
+  expect(resultDate.getDate()).toBe(22);
+  expect(resultDate.getMonth()).toBe(5);
+  expect(resultDate.getFullYear()).toBe(2025);
+  expect(isValid(resultDate)).toBe(true);
+}
+`,
+        errors: [
+          {
+            messageId: "requireIsValid",
+            suggestions: [
+              {
+                messageId: "suggestGuard",
+                output: `
+import { parseISO, isValid, differenceInDays } from 'date-fns';
+declare function expect(value: unknown): { toBe(expected: unknown): void };
+function testDateOffset(input: string, referenceDate: Date) {
+  const resultDate = parseISO(input);
+if (!isValid(resultDate)) {
+  // TODO: handle invalid date
+}
+
+  expect(differenceInDays(resultDate, referenceDate)).toBe(7);
+  expect(resultDate.getDate()).toBe(22);
+  expect(resultDate.getMonth()).toBe(5);
+  expect(resultDate.getFullYear()).toBe(2025);
+  expect(isValid(resultDate)).toBe(true);
+}
+`,
+              },
+            ],
+          },
+        ],
+      },
+
+      // ❌ Asserting isValid is false does NOT validate - date used after
+      {
+        code: `
+import { parseISO, isValid } from 'date-fns';
+declare function expect(value: unknown): { toBe(expected: unknown): void };
+function testInvalidDate(input: string) {
+  const d = parseISO(input);
+  expect(isValid(d)).toBe(false);
+  console.log(d.toString());
+}
+`,
+        errors: [
+          {
+            messageId: "requireIsValid",
+            suggestions: [
+              {
+                messageId: "suggestGuard",
+                output: `
+import { parseISO, isValid } from 'date-fns';
+declare function expect(value: unknown): { toBe(expected: unknown): void };
+function testInvalidDate(input: string) {
+  const d = parseISO(input);
+if (!isValid(d)) {
+  // TODO: handle invalid date
+}
+
+  expect(isValid(d)).toBe(false);
+  console.log(d.toString());
+}
+`,
+              },
+            ],
+          },
+        ],
+      },
+
+      // ❌ toBeFalsy() does NOT validate
+      {
+        code: `
+import { parseISO, isValid } from 'date-fns';
+declare function expect(value: unknown): { toBeFalsy(): void };
+function testInvalidDate(input: string) {
+  const d = parseISO(input);
+  expect(isValid(d)).toBeFalsy();
+  console.log(d.toString());
+}
+`,
+        errors: [
+          {
+            messageId: "requireIsValid",
+            suggestions: [
+              {
+                messageId: "suggestGuard",
+                output: `
+import { parseISO, isValid } from 'date-fns';
+declare function expect(value: unknown): { toBeFalsy(): void };
+function testInvalidDate(input: string) {
+  const d = parseISO(input);
+if (!isValid(d)) {
+  // TODO: handle invalid date
+}
+
+  expect(isValid(d)).toBeFalsy();
+  console.log(d.toString());
+}
+`,
+              },
+            ],
+          },
+        ],
+      },
+
+      // ❌ Chai-style to.be.false does NOT validate
+      {
+        code: `
+import { parseISO, isValid } from 'date-fns';
+declare function expect(value: unknown): { to: { be: { false: void } } };
+function testInvalidDate(input: string) {
+  const d = parseISO(input);
+  expect(isValid(d)).to.be.false;
+  console.log(d.toString());
+}
+`,
+        errors: [
+          {
+            messageId: "requireIsValid",
+            suggestions: [
+              {
+                messageId: "suggestGuard",
+                output: `
+import { parseISO, isValid } from 'date-fns';
+declare function expect(value: unknown): { to: { be: { false: void } } };
+function testInvalidDate(input: string) {
+  const d = parseISO(input);
+if (!isValid(d)) {
+  // TODO: handle invalid date
+}
+
+  expect(isValid(d)).to.be.false;
+  console.log(d.toString());
+}
+`,
+              },
+            ],
+          },
+        ],
+      },
+
+      // ❌ toEqual(false) does NOT validate
+      {
+        code: `
+import { parseISO, isValid } from 'date-fns';
+declare function expect(value: unknown): { toEqual(expected: unknown): void };
+function testInvalidDate(input: string) {
+  const d = parseISO(input);
+  expect(isValid(d)).toEqual(false);
+  console.log(d.toString());
+}
+`,
+        errors: [
+          {
+            messageId: "requireIsValid",
+            suggestions: [
+              {
+                messageId: "suggestGuard",
+                output: `
+import { parseISO, isValid } from 'date-fns';
+declare function expect(value: unknown): { toEqual(expected: unknown): void };
+function testInvalidDate(input: string) {
+  const d = parseISO(input);
+if (!isValid(d)) {
+  // TODO: handle invalid date
+}
+
+  expect(isValid(d)).toEqual(false);
+  console.log(d.toString());
 }
 `,
               },

--- a/test/rules/require-isvalid-after-parse.test.ts
+++ b/test/rules/require-isvalid-after-parse.test.ts
@@ -1548,6 +1548,42 @@ if (!isValid(d)) {
           },
         ],
       },
+
+      // ❌ toStrictEqual(false) does NOT validate
+      {
+        code: `
+import { parseISO, isValid } from 'date-fns';
+declare function expect(value: unknown): { toStrictEqual(expected: unknown): void };
+function testInvalidDate(input: string) {
+  const d = parseISO(input);
+  expect(isValid(d)).toStrictEqual(false);
+  console.log(d.toString());
+}
+`,
+        errors: [
+          {
+            messageId: "requireIsValid",
+            suggestions: [
+              {
+                messageId: "suggestGuard",
+                output: `
+import { parseISO, isValid } from 'date-fns';
+declare function expect(value: unknown): { toStrictEqual(expected: unknown): void };
+function testInvalidDate(input: string) {
+  const d = parseISO(input);
+if (!isValid(d)) {
+  // TODO: handle invalid date
+}
+
+  expect(isValid(d)).toStrictEqual(false);
+  console.log(d.toString());
+}
+`,
+              },
+            ],
+          },
+        ],
+      },
     ],
   });
 });


### PR DESCRIPTION
This pull request enhances the `require-isvalid-after-parse` ESLint rule to better recognize assertion-based validation patterns commonly used in tests, and to distinguish between positive and negative assertions for date validity. It updates the rule logic, documentation, and test cases to cover a wide range of assertion styles and ensures that only positive assertions (checking for validity) are considered as proper guards.

**Rule logic improvements:**

* Updated the rule's logic in `index.ts` to recognize assertion patterns such as `expect(isValid(date)).toBe(true)`, `assert(isValid(date))`, and Chai-style `.to.be.true` as valid guards, while explicitly excluding negative assertions like `.toBe(false)`, `.toBeFalsy()`, `.toEqual(false)`, and `.to.be.false` from being considered as validation.

**Documentation updates:**

* Expanded the documentation in `require-isvalid-after-parse.md` to clearly list which assertion patterns are accepted as valid guards and which are not, with concrete code examples for both valid and invalid cases.

**Test suite enhancements:**

* Added comprehensive test cases in `require-isvalid-after-parse.test.ts` to verify the rule's behavior with various assertion patterns, including both positive and negative assertions, and to ensure the rule only allows usage of parsed dates after proper validation.
* Added negative test cases to ensure the rule correctly flags code that uses parsed dates before validation or uses negative assertions, and provides suggestion outputs for proper guarding.